### PR TITLE
Include API path in base URL

### DIFF
--- a/lib/config/env.dart
+++ b/lib/config/env.dart
@@ -1,4 +1,4 @@
 class Env {
   // Ajusta según tu backend:
-  static const String apiBaseUrl = "http://192.168.1.202:3001";
+  static const String apiBaseUrl = "http://192.168.1.202:3001/api";
 }


### PR DESCRIPTION
## Summary
- append `/api` to the base URL constant

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7647180c88324a23de5b75c6ced78