### PR TITLE
Persist login token in repository

### DIFF
--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -7,12 +7,10 @@ class AuthRepository {
   AuthRepository(this._service);
 
   Future<User> login(String email, String password) async {
-    final user = await _service.login(email, password);
-    // Guarda token si viene en la respuesta; ajusta según tu API
+    final res = await _service.login(email, password);
     final prefs = await SharedPreferences.getInstance();
-    // Ej: res.data["token"]
-    // await prefs.setString("token", token);
-    return user;
+    await prefs.setString("token", res["token"] as String);
+    return res["user"] as User;
   }
 
   Future<void> logout({bool all = false}) async {

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -5,12 +5,15 @@ class AuthService {
   final ApiClient _client;
   AuthService(this._client);
 
-  Future<User> login(String email, String password) async {
+  Future<Map<String, dynamic>> login(String email, String password) async {
     final res = await _client.post("/auth/login", data: {
       "email": email,
       "password": password,
     });
-    return User.fromJson(res.data["user"]);
+    return {
+      "user": User.fromJson(res.data["user"]),
+      "token": res.data["token"],
+    };
   }
 
   Future<void> logout({bool all = false}) =>


### PR DESCRIPTION
## Summary
- Return authentication token from login service
- Save token to SharedPreferences through auth repository
- API client continues to inject token from repository into requests

## Testing
- `dart analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b764725c408324a52a13b26a55082f