### PR TITLE
Add singleton registrations for new services and repositories

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -2,7 +2,17 @@ import "package:get_it/get_it.dart";
 import "package:dio/dio.dart";
 import "../services/api_client.dart";
 import "../services/auth_service.dart";
+import "../services/group_service.dart";
+import "../services/invitation_service.dart";
+import "../services/expense_service.dart";
+import "../services/payment_service.dart";
+import "../services/notification_service.dart";
 import "../repositories/auth_repository.dart";
+import "../repositories/group_repository.dart";
+import "../repositories/invitation_repository.dart";
+import "../repositories/expense_repository.dart";
+import "../repositories/payment_repository.dart";
+import "../repositories/notification_repository.dart";
 
 final GetIt locator = GetIt.instance;
 
@@ -13,5 +23,16 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<ApiClient>(() => ApiClient(locator<Dio>()));
 
   locator.registerLazySingleton<AuthService>(() => AuthService(locator<ApiClient>()));
+  locator.registerLazySingleton<GroupService>(() => GroupService(locator<ApiClient>()));
+  locator.registerLazySingleton<InvitationService>(() => InvitationService(locator<ApiClient>()));
+  locator.registerLazySingleton<ExpenseService>(() => ExpenseService(locator<ApiClient>()));
+  locator.registerLazySingleton<PaymentService>(() => PaymentService(locator<ApiClient>()));
+  locator.registerLazySingleton<NotificationService>(() => NotificationService(locator<ApiClient>()));
+
   locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
+  locator.registerLazySingleton<GroupRepository>(() => GroupRepository(locator<GroupService>()));
+  locator.registerLazySingleton<InvitationRepository>(() => InvitationRepository(locator<InvitationService>()));
+  locator.registerLazySingleton<ExpenseRepository>(() => ExpenseRepository(locator<ExpenseService>()));
+  locator.registerLazySingleton<PaymentRepository>(() => PaymentRepository(locator<PaymentService>()));
+  locator.registerLazySingleton<NotificationRepository>(() => NotificationRepository(locator<NotificationService>()));
 }

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,1 +1,6 @@
+import "../services/expense_service.dart";
 
+class ExpenseRepository {
+  final ExpenseService _service;
+  ExpenseRepository(this._service);
+}

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,1 +1,6 @@
+import "../services/group_service.dart";
 
+class GroupRepository {
+  final GroupService _service;
+  GroupRepository(this._service);
+}

--- a/lib/repositories/invitation_repository.dart
+++ b/lib/repositories/invitation_repository.dart
@@ -1,1 +1,6 @@
+import "../services/invitation_service.dart";
 
+class InvitationRepository {
+  final InvitationService _service;
+  InvitationRepository(this._service);
+}

--- a/lib/repositories/notification_repository.dart
+++ b/lib/repositories/notification_repository.dart
@@ -1,1 +1,6 @@
+import "../services/notification_service.dart";
 
+class NotificationRepository {
+  final NotificationService _service;
+  NotificationRepository(this._service);
+}

--- a/lib/repositories/payment_repository.dart
+++ b/lib/repositories/payment_repository.dart
@@ -1,1 +1,6 @@
+import "../services/payment_service.dart";
 
+class PaymentRepository {
+  final PaymentService _service;
+  PaymentRepository(this._service);
+}

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -1,1 +1,6 @@
+import "../services/api_client.dart";
 
+class ExpenseService {
+  final ApiClient _client;
+  ExpenseService(this._client);
+}

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,1 +1,6 @@
+import "../services/api_client.dart";
 
+class GroupService {
+  final ApiClient _client;
+  GroupService(this._client);
+}

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,1 +1,6 @@
+import "../services/api_client.dart";
 
+class InvitationService {
+  final ApiClient _client;
+  InvitationService(this._client);
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,1 +1,6 @@
+import "../services/api_client.dart";
 
+class NotificationService {
+  final ApiClient _client;
+  NotificationService(this._client);
+}

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,1 +1,6 @@
+import "../services/api_client.dart";
 
+class PaymentService {
+  final ApiClient _client;
+  PaymentService(this._client);
+}


### PR DESCRIPTION
## Summary
- define empty services and repositories for groups, invitations, expenses, payments and notifications
- register lazy singletons for the new services and repositories in setupLocator

## Testing
- `dart format lib/config/locator.dart lib/services/group_service.dart lib/services/invitation_service.dart lib/services/expense_service.dart lib/services/payment_service.dart lib/services/notification_service.dart lib/repositories/group_repository.dart lib/repositories/invitation_repository.dart lib/repositories/expense_repository.dart lib/repositories/payment_repository.dart lib/repositories/notification_repository.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7647307908324a874a0aad0420efa