### PR TITLE
feat(auth): add registration and profile actions

### DIFF
--- a/lib/repositories/auth_repository.dart
+++ b/lib/repositories/auth_repository.dart
@@ -26,6 +26,21 @@ class AuthRepository {
     return prefs.getString("token");
   }
 
+  Future<User> register(String email, String password, {String? name}) async {
+    final user = await _service.register(email, password, name: name);
+    // Guarda token si es necesario
+    return user;
+  }
+
+  Future<User> updateProfile({String? name, String? email}) async {
+    final user = await _service.updateProfile(name: name, email: email);
+    return user;
+  }
+
+  Future<void> updatePassword(
+          String currentPassword, String newPassword) =>
+      _service.updatePassword(currentPassword, newPassword);
+
   // Singleton de conveniencia si lo deseas:
   static AuthRepository get instance => throw UnimplementedError("Usa GetIt locator<AuthRepository>()");
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -15,4 +15,29 @@ class AuthService {
 
   Future<void> logout({bool all = false}) =>
       _client.post("/auth/logout", query: {"all": all});
+
+  Future<User> register(String email, String password, {String? name}) async {
+    final res = await _client.post("/auth/register", data: {
+      "email": email,
+      "password": password,
+      "name": name,
+    });
+    return User.fromJson(res.data["user"]);
+  }
+
+  Future<User> updateProfile({String? name, String? email}) async {
+    final res = await _client.put("/auth/profile", data: {
+      "name": name,
+      "email": email,
+    });
+    return User.fromJson(res.data["user"]);
+  }
+
+  Future<void> updatePassword(
+      String currentPassword, String newPassword) async {
+    await _client.put("/auth/password", data: {
+      "current_password": currentPassword,
+      "new_password": newPassword,
+    });
+  }
 }

--- a/lib/state/auth/auth_provider.dart
+++ b/lib/state/auth/auth_provider.dart
@@ -21,6 +21,37 @@ class AuthNotifier extends StateNotifier<AuthState> {
     }
   }
 
+  Future<void> register(String email, String password, {String? name}) async {
+    state = const AuthLoading();
+    try {
+      final user = await _repo.register(email, password, name: name);
+      state = AuthRegistered(user.email);
+    } catch (e) {
+      state = AuthError(e.toString());
+    }
+  }
+
+  Future<void> updateProfile({String? name, String? email}) async {
+    state = const AuthLoading();
+    try {
+      final user = await _repo.updateProfile(name: name, email: email);
+      state = AuthProfileUpdated(user.email);
+    } catch (e) {
+      state = AuthError(e.toString());
+    }
+  }
+
+  Future<void> updatePassword(
+      String currentPassword, String newPassword) async {
+    state = const AuthLoading();
+    try {
+      await _repo.updatePassword(currentPassword, newPassword);
+      state = const AuthPasswordUpdated();
+    } catch (e) {
+      state = AuthError(e.toString());
+    }
+  }
+
   Future<void> logout() async {
     state = const AuthLoading();
     try {

--- a/lib/state/auth/auth_state.dart
+++ b/lib/state/auth/auth_state.dart
@@ -19,3 +19,17 @@ class AuthError extends AuthState {
   final String message;
   const AuthError(this.message);
 }
+
+class AuthRegistered extends AuthState {
+  final String userEmail;
+  const AuthRegistered(this.userEmail);
+}
+
+class AuthProfileUpdated extends AuthState {
+  final String userEmail;
+  const AuthProfileUpdated(this.userEmail);
+}
+
+class AuthPasswordUpdated extends AuthState {
+  const AuthPasswordUpdated();
+}


### PR DESCRIPTION
## Summary
- add register, profile and password endpoints to auth service/repository
- extend auth notifier with states/actions for register, profile update and password change

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b764749500832497133215412e49f5