### PR TITLE
Add models and CRUD services for groups, expenses, invitations and payments

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -3,6 +3,14 @@ import "package:dio/dio.dart";
 import "../services/api_client.dart";
 import "../services/auth_service.dart";
 import "../repositories/auth_repository.dart";
+import "../services/group_service.dart";
+import "../repositories/group_repository.dart";
+import "../services/expense_service.dart";
+import "../repositories/expense_repository.dart";
+import "../services/invitation_service.dart";
+import "../repositories/invitation_repository.dart";
+import "../services/payment_service.dart";
+import "../repositories/payment_repository.dart";
 
 final GetIt locator = GetIt.instance;
 
@@ -12,6 +20,22 @@ Future<void> setupLocator() async {
 
   locator.registerLazySingleton<ApiClient>(() => ApiClient(locator<Dio>()));
 
-  locator.registerLazySingleton<AuthService>(() => AuthService(locator<ApiClient>()));
-  locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
-}
+    locator.registerLazySingleton<AuthService>(() => AuthService(locator<ApiClient>()));
+    locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
+
+    locator.registerLazySingleton<GroupService>(() => GroupService(locator<ApiClient>()));
+    locator.registerLazySingleton<GroupRepository>(
+        () => GroupRepository(locator<GroupService>()));
+
+    locator.registerLazySingleton<ExpenseService>(() => ExpenseService(locator<ApiClient>()));
+    locator.registerLazySingleton<ExpenseRepository>(
+        () => ExpenseRepository(locator<ExpenseService>()));
+
+    locator.registerLazySingleton<InvitationService>(() => InvitationService(locator<ApiClient>()));
+    locator.registerLazySingleton<InvitationRepository>(
+        () => InvitationRepository(locator<InvitationService>()));
+
+    locator.registerLazySingleton<PaymentService>(() => PaymentService(locator<ApiClient>()));
+    locator.registerLazySingleton<PaymentRepository>(
+        () => PaymentRepository(locator<PaymentService>()));
+  }

--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,1 +1,38 @@
+class Expense {
+  final String id;
+  final String groupId;
+  final String description;
+  final double amount;
+  final String paidBy;
+  final DateTime date;
+
+  Expense({
+    required this.id,
+    required this.groupId,
+    required this.description,
+    required this.amount,
+    required this.paidBy,
+    required this.date,
+  });
+
+  factory Expense.fromJson(Map<String, dynamic> json) => Expense(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        description: json['description'] ?? '',
+        amount: (json['amount'] as num?)?.toDouble() ?? 0.0,
+        paidBy: json['paidBy']?.toString() ?? '',
+        date: json['date'] != null
+            ? DateTime.parse(json['date'])
+            : DateTime.now(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'description': description,
+        'amount': amount,
+        'paidBy': paidBy,
+        'date': date.toIso8601String(),
+      };
+}
 

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -1,1 +1,29 @@
+class Group {
+  final String id;
+  final String name;
+  final String? description;
+  final List<String>? members;
+
+  Group({
+    required this.id,
+    required this.name,
+    this.description,
+    this.members,
+  });
+
+  factory Group.fromJson(Map<String, dynamic> json) => Group(
+        id: json['id'].toString(),
+        name: json['name'] ?? '',
+        description: json['description'],
+        members:
+            (json['members'] as List?)?.map((m) => m.toString()).toList(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'members': members,
+      };
+}
 

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -1,1 +1,28 @@
+class Invitation {
+  final String id;
+  final String groupId;
+  final String email;
+  final String status;
+
+  Invitation({
+    required this.id,
+    required this.groupId,
+    required this.email,
+    required this.status,
+  });
+
+  factory Invitation.fromJson(Map<String, dynamic> json) => Invitation(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        email: json['email'] ?? '',
+        status: json['status'] ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'email': email,
+        'status': status,
+      };
+}
 

--- a/lib/models/payment.dart
+++ b/lib/models/payment.dart
@@ -1,1 +1,38 @@
+class Payment {
+  final String id;
+  final String groupId;
+  final String fromUserId;
+  final String toUserId;
+  final double amount;
+  final DateTime date;
+
+  Payment({
+    required this.id,
+    required this.groupId,
+    required this.fromUserId,
+    required this.toUserId,
+    required this.amount,
+    required this.date,
+  });
+
+  factory Payment.fromJson(Map<String, dynamic> json) => Payment(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        fromUserId: json['fromUserId']?.toString() ?? '',
+        toUserId: json['toUserId']?.toString() ?? '',
+        amount: (json['amount'] as num?)?.toDouble() ?? 0.0,
+        date: json['date'] != null
+            ? DateTime.parse(json['date'])
+            : DateTime.now(),
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'fromUserId': fromUserId,
+        'toUserId': toUserId,
+        'amount': amount,
+        'date': date.toIso8601String(),
+      };
+}
 

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,1 +1,23 @@
+import '../models/expense.dart';
+import '../services/expense_service.dart';
+
+class ExpenseRepository {
+  final ExpenseService _service;
+  ExpenseRepository(this._service);
+
+  Future<List<Expense>> getExpenses(String groupId) =>
+      _service.getExpenses(groupId);
+
+  Future<Expense> getExpense(String groupId, String id) =>
+      _service.getExpense(groupId, id);
+
+  Future<Expense> createExpense(String groupId, Expense expense) =>
+      _service.createExpense(groupId, expense);
+
+  Future<Expense> updateExpense(String groupId, Expense expense) =>
+      _service.updateExpense(groupId, expense);
+
+  Future<void> deleteExpense(String groupId, String id) =>
+      _service.deleteExpense(groupId, id);
+}
 

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,1 +1,18 @@
+import '../models/group.dart';
+import '../services/group_service.dart';
+
+class GroupRepository {
+  final GroupService _service;
+  GroupRepository(this._service);
+
+  Future<List<Group>> getGroups() => _service.getGroups();
+
+  Future<Group> getGroup(String id) => _service.getGroup(id);
+
+  Future<Group> createGroup(Group group) => _service.createGroup(group);
+
+  Future<Group> updateGroup(Group group) => _service.updateGroup(group);
+
+  Future<void> deleteGroup(String id) => _service.deleteGroup(id);
+}
 

--- a/lib/repositories/invitation_repository.dart
+++ b/lib/repositories/invitation_repository.dart
@@ -1,1 +1,22 @@
+import '../models/invitation.dart';
+import '../services/invitation_service.dart';
+
+class InvitationRepository {
+  final InvitationService _service;
+  InvitationRepository(this._service);
+
+  Future<List<Invitation>> getInvitations(String groupId) =>
+      _service.getInvitations(groupId);
+
+  Future<Invitation> getInvitation(String id) => _service.getInvitation(id);
+
+  Future<Invitation> createInvitation(
+          String groupId, Invitation invitation) =>
+      _service.createInvitation(groupId, invitation);
+
+  Future<Invitation> updateInvitation(Invitation invitation) =>
+      _service.updateInvitation(invitation);
+
+  Future<void> deleteInvitation(String id) => _service.deleteInvitation(id);
+}
 

--- a/lib/repositories/payment_repository.dart
+++ b/lib/repositories/payment_repository.dart
@@ -1,1 +1,23 @@
+import '../models/payment.dart';
+import '../services/payment_service.dart';
+
+class PaymentRepository {
+  final PaymentService _service;
+  PaymentRepository(this._service);
+
+  Future<List<Payment>> getPayments(String groupId) =>
+      _service.getPayments(groupId);
+
+  Future<Payment> getPayment(String groupId, String id) =>
+      _service.getPayment(groupId, id);
+
+  Future<Payment> createPayment(String groupId, Payment payment) =>
+      _service.createPayment(groupId, payment);
+
+  Future<Payment> updatePayment(String groupId, Payment payment) =>
+      _service.updatePayment(groupId, payment);
+
+  Future<void> deletePayment(String groupId, String id) =>
+      _service.deletePayment(groupId, id);
+}
 

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -1,1 +1,35 @@
+import '../models/expense.dart';
+import 'api_client.dart';
+
+class ExpenseService {
+  final ApiClient _client;
+  ExpenseService(this._client);
+
+  Future<List<Expense>> getExpenses(String groupId) async {
+    final res = await _client.get('/groups/$groupId/expenses');
+    final data = res.data as List;
+    return data.map((e) => Expense.fromJson(e)).toList();
+  }
+
+  Future<Expense> getExpense(String groupId, String id) async {
+    final res = await _client.get('/groups/$groupId/expenses/$id');
+    return Expense.fromJson(res.data);
+  }
+
+  Future<Expense> createExpense(String groupId, Expense expense) async {
+    final res = await _client.post('/groups/$groupId/expenses',
+        data: expense.toJson());
+    return Expense.fromJson(res.data);
+  }
+
+  Future<Expense> updateExpense(String groupId, Expense expense) async {
+    final res = await _client.put(
+        '/groups/$groupId/expenses/${expense.id}',
+        data: expense.toJson());
+    return Expense.fromJson(res.data);
+  }
+
+  Future<void> deleteExpense(String groupId, String id) =>
+      _client.delete('/groups/$groupId/expenses/$id');
+}
 

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,1 +1,31 @@
+import '../models/group.dart';
+import 'api_client.dart';
+
+class GroupService {
+  final ApiClient _client;
+  GroupService(this._client);
+
+  Future<List<Group>> getGroups() async {
+    final res = await _client.get('/groups');
+    final data = res.data as List;
+    return data.map((g) => Group.fromJson(g)).toList();
+    }
+
+  Future<Group> getGroup(String id) async {
+    final res = await _client.get('/groups/$id');
+    return Group.fromJson(res.data);
+  }
+
+  Future<Group> createGroup(Group group) async {
+    final res = await _client.post('/groups', data: group.toJson());
+    return Group.fromJson(res.data);
+  }
+
+  Future<Group> updateGroup(Group group) async {
+    final res = await _client.put('/groups/${group.id}', data: group.toJson());
+    return Group.fromJson(res.data);
+  }
+
+  Future<void> deleteGroup(String id) => _client.delete('/groups/$id');
+}
 

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,1 +1,35 @@
+import '../models/invitation.dart';
+import 'api_client.dart';
+
+class InvitationService {
+  final ApiClient _client;
+  InvitationService(this._client);
+
+  Future<List<Invitation>> getInvitations(String groupId) async {
+    final res = await _client.get('/groups/$groupId/invitations');
+    final data = res.data as List;
+    return data.map((i) => Invitation.fromJson(i)).toList();
+  }
+
+  Future<Invitation> getInvitation(String id) async {
+    final res = await _client.get('/invitations/$id');
+    return Invitation.fromJson(res.data);
+  }
+
+  Future<Invitation> createInvitation(
+      String groupId, Invitation invitation) async {
+    final res = await _client.post('/groups/$groupId/invitations',
+        data: invitation.toJson());
+    return Invitation.fromJson(res.data);
+  }
+
+  Future<Invitation> updateInvitation(Invitation invitation) async {
+    final res = await _client.put('/invitations/${invitation.id}',
+        data: invitation.toJson());
+    return Invitation.fromJson(res.data);
+  }
+
+  Future<void> deleteInvitation(String id) =>
+      _client.delete('/invitations/$id');
+}
 

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,1 +1,35 @@
+import '../models/payment.dart';
+import 'api_client.dart';
+
+class PaymentService {
+  final ApiClient _client;
+  PaymentService(this._client);
+
+  Future<List<Payment>> getPayments(String groupId) async {
+    final res = await _client.get('/groups/$groupId/payments');
+    final data = res.data as List;
+    return data.map((p) => Payment.fromJson(p)).toList();
+  }
+
+  Future<Payment> getPayment(String groupId, String id) async {
+    final res = await _client.get('/groups/$groupId/payments/$id');
+    return Payment.fromJson(res.data);
+  }
+
+  Future<Payment> createPayment(String groupId, Payment payment) async {
+    final res = await _client.post('/groups/$groupId/payments',
+        data: payment.toJson());
+    return Payment.fromJson(res.data);
+  }
+
+  Future<Payment> updatePayment(String groupId, Payment payment) async {
+    final res = await _client.put(
+        '/groups/$groupId/payments/${payment.id}',
+        data: payment.toJson());
+    return Payment.fromJson(res.data);
+  }
+
+  Future<void> deletePayment(String groupId, String id) =>
+      _client.delete('/groups/$groupId/payments/$id');
+}
 


### PR DESCRIPTION
## Summary
- define Group, Expense, Invitation and Payment models with JSON serialization helpers
- implement CRUD services and repositories for groups, expenses, invitations and payments
- register new services and repositories in dependency locator

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76475b7bc83249a94f0ed311e464f