### PR TITLE
Add basic state management and screens for groups and expenses

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -3,6 +3,8 @@ import "package:dio/dio.dart";
 import "../services/api_client.dart";
 import "../services/auth_service.dart";
 import "../repositories/auth_repository.dart";
+import "../repositories/group_repository.dart";
+import "../repositories/expense_repository.dart";
 
 final GetIt locator = GetIt.instance;
 
@@ -12,6 +14,11 @@ Future<void> setupLocator() async {
 
   locator.registerLazySingleton<ApiClient>(() => ApiClient(locator<Dio>()));
 
-  locator.registerLazySingleton<AuthService>(() => AuthService(locator<ApiClient>()));
-  locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
+  locator.registerLazySingleton<AuthService>(
+      () => AuthService(locator<ApiClient>()));
+  locator.registerLazySingleton<AuthRepository>(
+      () => AuthRepository(locator<AuthService>()));
+
+  locator.registerLazySingleton<GroupRepository>(() => GroupRepository());
+  locator.registerLazySingleton<ExpenseRepository>(() => ExpenseRepository());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,8 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'config/locator.dart';
+import 'ui/routes.dart';
 import 'ui/screens/login_screen.dart';
 import 'ui/screens/dashboard_screen.dart';
+import 'ui/screens/groups/group_list_screen.dart';
+import 'ui/screens/groups/group_detail_screen.dart';
+import 'ui/screens/groups/group_form_screen.dart';
+import 'ui/screens/expenses/expense_list_screen.dart';
+import 'ui/screens/expenses/expense_detail_screen.dart';
+import 'ui/screens/expenses/expense_form_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,17 +23,39 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final _router = GoRouter(
-      initialLocation: "/login",
+    final router = GoRouter(
+      initialLocation: AppRoutes.login,
       routes: [
-        GoRoute(path: "/login", builder: (_, __) => const LoginScreen()),
-        GoRoute(path: "/dashboard", builder: (_, __) => const DashboardScreen()),
+        GoRoute(path: AppRoutes.login, builder: (_, __) => const LoginScreen()),
+        GoRoute(
+            path: AppRoutes.dashboard,
+            builder: (_, __) => const DashboardScreen()),
+        GoRoute(path: AppRoutes.groups,
+            builder: (_, __) => const GroupListScreen()),
+        GoRoute(path: AppRoutes.groupForm,
+            builder: (_, __) => const GroupFormScreen()),
+        GoRoute(
+            path: '/groups/:id',
+            builder: (_, state) =>
+                GroupDetailScreen(id: state.pathParameters['id']!)),
+        GoRoute(
+            path: '/groups/:id/expenses',
+            builder: (_, state) =>
+                ExpenseListScreen(groupId: state.pathParameters['id']!)),
+        GoRoute(
+            path: '/groups/:id/expenses/new',
+            builder: (_, state) =>
+                ExpenseFormScreen(groupId: state.pathParameters['id']!)),
+        GoRoute(
+            path: '/groups/:id/expenses/:expId',
+            builder: (_, state) =>
+                ExpenseDetailScreen(id: state.pathParameters['expId']!)),
       ],
     );
 
     return MaterialApp.router(
-      title: "SSDS App",
-      routerConfig: _router,
+      title: 'SSDS App',
+      routerConfig: router,
       theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
     );
   }

--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -1,1 +1,27 @@
+class Expense {
+  final String id;
+  final String groupId;
+  final String description;
+  final double amount;
 
+  Expense({
+    required this.id,
+    required this.groupId,
+    required this.description,
+    required this.amount,
+  });
+
+  factory Expense.fromJson(Map<String, dynamic> json) => Expense(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        description: json['description'] ?? '',
+        amount: (json['amount'] as num?)?.toDouble() ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'description': description,
+        'amount': amount,
+      };
+}

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -1,1 +1,16 @@
+class Group {
+  final String id;
+  final String name;
 
+  Group({required this.id, required this.name});
+
+  factory Group.fromJson(Map<String, dynamic> json) => Group(
+        id: json['id'].toString(),
+        name: json['name'] ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+      };
+}

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,1 +1,28 @@
+import '../models/expense.dart';
 
+class ExpenseRepository {
+  final List<Expense> _expenses = [];
+
+  Future<List<Expense>> fetchExpenses(String groupId) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return _expenses.where((e) => e.groupId == groupId).toList();
+  }
+
+  Future<Expense> getExpense(String id) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return _expenses.firstWhere((e) => e.id == id);
+  }
+
+  Future<Expense> addExpense(
+      String groupId, String description, double amount) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final expense = Expense(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      groupId: groupId,
+      description: description,
+      amount: amount,
+    );
+    _expenses.add(expense);
+    return expense;
+  }
+}

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,1 +1,23 @@
+import '../models/group.dart';
 
+class GroupRepository {
+  final List<Group> _groups = [];
+
+  Future<List<Group>> fetchGroups() async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return [..._groups];
+  }
+
+  Future<Group> getGroup(String id) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    return _groups.firstWhere((g) => g.id == id);
+  }
+
+  Future<Group> addGroup(String name) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final group =
+        Group(id: DateTime.now().millisecondsSinceEpoch.toString(), name: name);
+    _groups.add(group);
+    return group;
+  }
+}

--- a/lib/state/expenses/expense_state.dart
+++ b/lib/state/expenses/expense_state.dart
@@ -1,0 +1,27 @@
+import '../../models/expense.dart';
+
+class ExpenseState {
+  final List<Expense> expenses;
+  final bool isLoading;
+  final String? error;
+
+  const ExpenseState({
+    this.expenses = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  ExpenseState copyWith({
+    List<Expense>? expenses,
+    bool? isLoading,
+    String? error,
+  }) {
+    return ExpenseState(
+      expenses: expenses ?? this.expenses,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+
+  factory ExpenseState.initial() => const ExpenseState();
+}

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../config/locator.dart';
+import '../../repositories/group_repository.dart';
+import '../../models/group.dart';
+import 'group_state.dart';
+
+final groupNotifierProvider =
+    StateNotifierProvider<GroupNotifier, GroupState>((ref) {
+  return GroupNotifier(locator<GroupRepository>());
+});
+
+class GroupNotifier extends StateNotifier<GroupState> {
+  final GroupRepository _repo;
+  GroupNotifier(this._repo) : super(GroupState.initial());
+
+  Future<void> fetchGroups() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final groups = await _repo.fetchGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> addGroup(String name) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repo.addGroup(name);
+      final groups = await _repo.fetchGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Group? getById(String id) {
+    try {
+      return state.groups.firstWhere((g) => g.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/state/groups/group_state.dart
+++ b/lib/state/groups/group_state.dart
@@ -1,0 +1,27 @@
+import '../../models/group.dart';
+
+class GroupState {
+  final List<Group> groups;
+  final bool isLoading;
+  final String? error;
+
+  const GroupState({
+    this.groups = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  GroupState copyWith({
+    List<Group>? groups,
+    bool? isLoading,
+    String? error,
+  }) {
+    return GroupState(
+      groups: groups ?? this.groups,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+
+  factory GroupState.initial() => const GroupState();
+}

--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -1,4 +1,10 @@
 class AppRoutes {
-  static const login = "/login";
-  static const dashboard = "/dashboard";
+  static const login = '/login';
+  static const dashboard = '/dashboard';
+  static const groups = '/groups';
+  static const groupForm = '/groups/new';
+  static const groupDetail = '/groups/:id';
+  static const expenses = '/groups/:id/expenses';
+  static const expenseForm = '/groups/:id/expenses/new';
+  static const expenseDetail = '/groups/:id/expenses/:expId';
 }

--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -1,4 +1,5 @@
-import "package:flutter/material.dart";
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({super.key});
@@ -6,8 +7,13 @@ class DashboardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text("Dashboard")),
-      body: const Center(child: Text("Resumen /dashboard/summary")),
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => context.push('/groups'),
+          child: const Text('Ver grupos'),
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/screens/expenses/expense_detail_screen.dart
+++ b/lib/ui/screens/expenses/expense_detail_screen.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../../state/expenses/expense_provider.dart';
+
+class ExpenseDetailScreen extends ConsumerWidget {
+  final String id;
+  const ExpenseDetailScreen({super.key, required this.id});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final expense = ref.read(expenseNotifierProvider.notifier).getById(id);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(expense?.description ?? 'Gasto')),
+      body: expense == null
+          ? const Center(child: Text('Gasto no encontrado'))
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Descripción: ${expense.description}'),
+                  Text('Monto: \\$${expense.amount.toStringAsFixed(2)}'),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/lib/ui/screens/expenses/expense_form_screen.dart
+++ b/lib/ui/screens/expenses/expense_form_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../state/expenses/expense_provider.dart';
+
+class ExpenseFormScreen extends HookConsumerWidget {
+  final String groupId;
+  const ExpenseFormScreen({super.key, required this.groupId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final descController = useTextEditingController();
+    final amountController = useTextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Nuevo Gasto')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: descController,
+              decoration: const InputDecoration(labelText: 'Descripción'),
+            ),
+            TextField(
+              controller: amountController,
+              decoration: const InputDecoration(labelText: 'Monto'),
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                final amount = double.tryParse(amountController.text) ?? 0;
+                await ref
+                    .read(expenseNotifierProvider.notifier)
+                    .addExpense(groupId, descController.text, amount);
+                if (context.mounted) {
+                  context.pop();
+                }
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/expenses/expense_list_screen.dart
+++ b/lib/ui/screens/expenses/expense_list_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../state/expenses/expense_provider.dart';
+
+class ExpenseListScreen extends HookConsumerWidget {
+  final String groupId;
+  const ExpenseListScreen({super.key, required this.groupId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(expenseNotifierProvider);
+
+    useEffect(() {
+      ref.read(expenseNotifierProvider.notifier).fetchExpenses(groupId);
+      return null;
+    }, [groupId]);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Gastos')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: state.expenses.length,
+              itemBuilder: (_, index) {
+                final expense = state.expenses[index];
+                return ListTile(
+                  title: Text(expense.description),
+                  subtitle: Text('\\$${expense.amount.toStringAsFixed(2)}'),
+                  onTap: () =>
+                      context.push('/groups/$groupId/expenses/${expense.id}'),
+                );
+              },
+            ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.push('/groups/$groupId/expenses/new'),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/groups/group_detail_screen.dart
+++ b/lib/ui/screens/groups/group_detail_screen.dart
@@ -1,14 +1,36 @@
-import "package:flutter/material.dart";
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../state/groups/group_provider.dart';
 
-class GroupDetailScreen extends StatelessWidget {
+class GroupDetailScreen extends ConsumerWidget {
   final String id;
   const GroupDetailScreen({super.key, required this.id});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final group = ref.read(groupNotifierProvider.notifier).getById(id);
+
     return Scaffold(
-      appBar: AppBar(title: Text("Grupo $id")),
-      body: const Center(child: Text("Detalle de grupo")),
+      appBar: AppBar(title: Text(group?.name ?? 'Grupo')),
+      body: group == null
+          ? const Center(child: Text('Grupo no encontrado'))
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('ID: ${group.id}'),
+                  Text('Nombre: ${group.name}'),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: () =>
+                        context.push('/groups/${group.id}/expenses'),
+                    child: const Text('Ver gastos'),
+                  ),
+                ],
+              ),
+            ),
     );
   }
 }

--- a/lib/ui/screens/groups/group_form_screen.dart
+++ b/lib/ui/screens/groups/group_form_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../state/groups/group_provider.dart';
+
+class GroupFormScreen extends HookConsumerWidget {
+  const GroupFormScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final nameController = useTextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Nuevo Grupo')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(labelText: 'Nombre'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                await ref
+                    .read(groupNotifierProvider.notifier)
+                    .addGroup(nameController.text);
+                if (context.mounted) {
+                  context.pop();
+                }
+              },
+              child: const Text('Guardar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/groups/group_list_screen.dart
+++ b/lib/ui/screens/groups/group_list_screen.dart
@@ -1,12 +1,39 @@
-import "package:flutter/material.dart";
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../state/groups/group_provider.dart';
 
-class GroupListScreen extends StatelessWidget {
+class GroupListScreen extends HookConsumerWidget {
   const GroupListScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text("Lista de grupos")),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(groupNotifierProvider);
+
+    useEffect(() {
+      ref.read(groupNotifierProvider.notifier).fetchGroups();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Grupos')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: state.groups.length,
+              itemBuilder: (_, index) {
+                final group = state.groups[index];
+                return ListTile(
+                  title: Text(group.name),
+                  onTap: () => context.push('/groups/${group.id}'),
+                );
+              },
+            ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => context.push('/groups/new'),
+        child: const Icon(Icons.add),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- implement in-memory repositories for groups and expenses
- add Riverpod state notifiers and providers for groups and expenses
- create basic list, detail, and form screens wired to providers and routes

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b764765178832493ae5da65ab7e49a