### PR TITLE
feat: add prototype Flutter screens

### DIFF
--- a/lib/ui/prototypes/add_expense_page.dart
+++ b/lib/ui/prototypes/add_expense_page.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+const lightSage = Color(0xFFF0F3F0);
+const warmGray = Color(0xFFD6D3D1);
+const accentColor = Color(0xFFE0E7FF);
+
+class AddExpensePage extends StatelessWidget {
+  const AddExpensePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: lightSage,
+      appBar: AppBar(title: const Text('Agregar Gasto')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(decoration: _input('Descripción')),
+            const SizedBox(height: 16),
+            TextField(
+              decoration: _input('Monto total'),
+              keyboardType: TextInputType.number,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              decoration: _input('Fecha'),
+              keyboardType: TextInputType.datetime,
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              decoration: _input('Grupo'),
+              items: const [
+                DropdownMenuItem(value: 'playa', child: Text('Viaje a la playa')),
+                DropdownMenuItem(value: 'cena', child: Text('Cena con amigos')),
+              ],
+              onChanged: (_) {},
+            ),
+            const SizedBox(height: 20),
+            SwitchListTile(
+              title: const Text('¿Tiene ticket?'),
+              value: false,
+              onChanged: (_) {},
+            ),
+            const SizedBox(height: 24),
+            const Text('Distribución',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 12),
+            _distributionTile('Sofía', 0.5, 25),
+            const SizedBox(height: 8),
+            _distributionTile('Mateo', 0.5, 25),
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: accentColor,
+            shape: const StadiumBorder(),
+            minimumSize: const Size.fromHeight(48),
+          ),
+          onPressed: () {},
+          child: const Text('Guardar'),
+        ),
+      ),
+    );
+  }
+
+  InputDecoration _input(String hint) => InputDecoration(
+        hintText: hint,
+        filled: true,
+        fillColor: Colors.white,
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      );
+
+  Widget _distributionTile(String name, double percent, double amount) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: warmGray.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: [
+          const CircleAvatar(),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(name,
+                    style: const TextStyle(fontWeight: FontWeight.w600)),
+                Text('${(percent * 100).round()}%'),
+              ],
+            ),
+          ),
+          SizedBox(
+            width: 60,
+            child: Text('\\$${amount.toStringAsFixed(2)}',
+                textAlign: TextAlign.right),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui/prototypes/dashboard_page.dart
+++ b/lib/ui/prototypes/dashboard_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+const softSage = Color(0xFFE8EAE6);
+const lightLavender = Color(0xFFE6E6FA);
+const textSecondary = Color(0xFF6B7280);
+const accentColor = Color(0xFFE6E6FA);
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        leading: Padding(
+          padding: const EdgeInsets.all(8),
+          child: CircleAvatar(
+            backgroundImage: NetworkImage('https://lh3.googleusercontent.com/aida-public/AB6AXuA0yggCah09VSrWLQs9C3bO0qaPY6T5EAd4jaE6uIWX4VW8_3P6MvdqvbwlKldSns0Gcdzleo_2swHIoGE3URRxqpJabFv2d57SuoLNgdO0xBxgBZGCAUTZXAFauDXCy2aA9ivvFKXS_v10XQFXaCu1SAwO_K-ilKAq558MMlgEB5gQpLlGPKgCJBi90gHU3nftAnDkkLXTUPMDZxkvE5fpc9d3Q-Cnn_5Q3a50IYEqcprtZpnjEBgxhzw431yXQC4M7gUvioow5Cdr'),
+          ),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const SectionTitle('Gastos Recientes'),
+          _recentExpenseTile('Cuenta del Restaurante', 'Cena', 45),
+          _recentExpenseTile('Supermercado', 'Compras', 78.5),
+          _recentExpenseTile('Factura de Electricidad', 'Servicios', 62.25),
+          const SectionTitle('Deudas Pendientes'),
+          _debtTile('Liam', 'Vacaciones', 25),
+          _debtTile('Sophia', 'Alquiler', 50),
+          const SectionTitle('Actividad de Grupo'),
+          _activityTile('Vacaciones', 'Liam añadió un nuevo gasto.', '2h'),
+          _activityTile('Alquiler', 'Sophia pagó su parte.', '4h'),
+        ],
+      ),
+      bottomNavigationBar: const BottomNavigationBar(
+        currentIndex: 1,
+        items: [
+          BottomNavigationBarItem(icon: Icon(Icons.groups), label: 'Grupos'),
+          BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
+          BottomNavigationBarItem(icon: Icon(Icons.payments), label: 'Pagos'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
+        ],
+      ),
+    );
+  }
+
+  Widget _recentExpenseTile(String title, String cat, double amount) {
+    return ListTile(
+      leading: const CircleAvatar(backgroundColor: accentColor),
+      title: Text(title),
+      subtitle: Text(cat),
+      trailing: Text('\\$${amount.toStringAsFixed(2)}'),
+    );
+  }
+
+  Widget _debtTile(String name, String cat, double amount) {
+    return ListTile(
+      leading: const CircleAvatar(),
+      title: Text(name),
+      subtitle: Text(cat),
+      trailing: Text('\\$${amount.toStringAsFixed(2)}',
+          style: const TextStyle(color: Colors.red)),
+    );
+  }
+
+  Widget _activityTile(String group, String action, String time) {
+    return ListTile(
+      leading: const CircleAvatar(backgroundColor: accentColor),
+      title: Text(group),
+      subtitle: Text(action),
+      trailing: Text(time, style: const TextStyle(fontSize: 12)),
+    );
+  }
+}
+
+class SectionTitle extends StatelessWidget {
+  final String text;
+  const SectionTitle(this.text, {super.key});
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 24, bottom: 8),
+      child: Text(text,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+    );
+  }
+}
+

--- a/lib/ui/prototypes/group_detail_page.dart
+++ b/lib/ui/prototypes/group_detail_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+
+const backgroundColor = Color(0xFFF8F9FA);
+const primaryColor = Color(0xFFD8E2DC);
+const textSecondary = Color(0xFF6C757D);
+const accentColor = Color(0xFFE6E6FA);
+const accentColorDark = Color(0xFFB5B5D1);
+const successColor = Color(0xFFA3B8A3);
+const warningColor = Color(0xFFDCA3A3);
+
+class GroupDetailPage extends StatelessWidget {
+  const GroupDetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: backgroundColor,
+      appBar: AppBar(
+        title: const Text('Viaje a la playa'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () {},
+        ),
+        actions: [IconButton(icon: const Icon(Icons.more_horiz), onPressed: () {})],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const Text('Gastos recientes',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          _expenseTile('Cena en el restaurante', 'Comida', 85),
+          _expenseTile('Alquiler de coche', 'Transporte', 150),
+          _expenseTile('Hotel', 'Alojamiento', 300),
+          const SizedBox(height: 24),
+          const Text('Miembros del grupo',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          const CircleAvatarGroup(
+            urls: [
+              'https://lh3.googleusercontent.com/aida-public/AB6AXuABP1Cg2tF-nDmdwQL3b_jsEgAoaJT67v6wLbXu-vLrc2d6sKJjkplSgWuB-VvPGTG0SDHZ_tg1lIlKnjcE8aYokzLwd8kRqgT70ExQF471pLKdgp6tt8IFmauuOCap9lrsYQfo0BpBvGFgozK6IGczGGJJo0XzCJa658rggmxrN3qmWEndVjjuU0hgdvqiL4WgMqAiM1-vi1SnW4dPhKR6JXTcI6F3NZPV0lGDZujLHL3gMCkea15-41W48rlC_KQ-FGqA9ORTMVZy',
+              'https://lh3.googleusercontent.com/aida-public/AB6AXuBlTlR-2p8s0nM3uRXNe6zFzmnnfSBScA28w3Xskzrs9XYPMvZ2HqKqhLjRnB0txp8Lv73B7U2Sfy1w1CEwH77rcMLP-l2zum5Qg1ks6xhut8Hk8clrVglyXRuiQ1ZZna55S6BtSgHGwaqBK9b4wp-oKe9YxVtKz9M53zLAVdX2f_chGcl_iCIHET_sNPLPBf7GeZA4zgZK22H7SolhTUZl_yqJVwtwVa9xyvZYcj-sxp3XfipK0Fhj7rDgaSo_sdQe6xPg287doUOf',
+              'https://lh3.googleusercontent.com/aida-public/AB6AXuB5YxzYD-pDJtQDXhQpGdUYoQcli6isDhrjf12_srsE2UJZ75pR8uZNTNrqIveHIuTnBHDnOtYUgAxyH_7ygk5zt83kmUD7V-W5wmNb4n-tbi2H4z319QGD2nXNWrLYP3viYEwJX33DAnEB0yw-0QJJjcCsgEg5ZbqFnF3Pi5JSTQBhuCANr4BnAyaCZ3v4uajtTo49yusLZsl0hjZmFqfSEJKqBc87GMBCBjnJd2FQCeec3PSfKl4jnDpD8nnfXsH8Nb2NcIJWLjan',
+            ],
+            extraCount: 2,
+          ),
+          const SizedBox(height: 24),
+          const Text('Resumen de balances',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          _balanceTile('Sofía', -25),
+          _balanceTile('Carlos', -15),
+          _balanceTile('Javier', 40),
+        ],
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+        child: Row(
+          children: [
+            Expanded(
+              child: ElevatedButton(
+                onPressed: () {},
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: accentColor,
+                  shape: const StadiumBorder(),
+                ),
+                child: const Text('Añadir gasto'),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: OutlinedButton(
+                onPressed: () {},
+                style: OutlinedButton.styleFrom(
+                  shape: const StadiumBorder(),
+                  side: const BorderSide(color: Colors.black),
+                ),
+                child: const Text('Ver detalles'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Widget _expenseTile(String title, String category, double amount) {
+  return ListTile(
+    leading: const CircleAvatar(backgroundColor: accentColor),
+    title: Text(title),
+    subtitle: Text(category, style: const TextStyle(color: textSecondary)),
+    trailing: Text('\\$${amount.toStringAsFixed(2)}',
+        style: const TextStyle(fontWeight: FontWeight.bold)),
+  );
+}
+
+Widget _balanceTile(String name, double amount) {
+  final isPositive = amount >= 0;
+  final color = isPositive ? successColor : warningColor;
+  final text = isPositive ? 'Te debe' : 'Debes';
+  return ListTile(
+    leading: const CircleAvatar(),
+    title: Text(name),
+    subtitle: Text(text, style: TextStyle(color: color)),
+    trailing: Text('\\$${amount.abs().toStringAsFixed(2)}',
+        style: TextStyle(fontWeight: FontWeight.bold, color: color)),
+  );
+}
+
+class CircleAvatarGroup extends StatelessWidget {
+  final List<String> urls;
+  final int extraCount;
+  const CircleAvatarGroup({super.key, required this.urls, this.extraCount = 0});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 48,
+      child: Stack(
+        children: [
+          for (int i = 0; i < urls.length; i++)
+            Positioned(
+              left: i * 28,
+              child: CircleAvatar(
+                radius: 24,
+                backgroundImage: NetworkImage(urls[i]),
+              ),
+            ),
+          if (extraCount > 0)
+            Positioned(
+              left: urls.length * 28,
+              child: CircleAvatar(
+                radius: 24,
+                backgroundColor: accentColor,
+                child: Text('+$extraCount',
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui/prototypes/groups_page.dart
+++ b/lib/ui/prototypes/groups_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+const lightGray = Color(0xFFF5F5F5);
+const blueishGray = Color(0xFF7C8B9A);
+
+class GroupsPage extends StatelessWidget {
+  const GroupsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = [
+      {
+        'title': 'Viaje a la playa',
+        'members': '3 miembros, 12 gastos',
+        'image': 'https://lh3.googleusercontent.com/aida-public/AB6AXuAwDjdRzRplnUx5pcTvXxQCmJ6A_njh2nBUWzTr8eVWIbW3wVhOzVJUouKTvslPCcLJDC6Gf8lE2Hbwhpuj1xGkjg_iR9mNvYj4o7bUcEXEINWiTF1GMMxyiZvsiHoN8jSzO4EmfSC1M92ZEA4bcNX49HBPO2ZiTdUNEZI9-ugwbp9GpfpFPbLYffKbreRkj0STcnjgQPr7ikQ31ybftWQl3OeCHr-murrimRQ1QjpwbNmxAyWmFOw_CMBvqWugv3ke6J035dV3M5_G',
+      },
+      {
+        'title': 'Cena con amigos',
+        'members': '2 miembros, 5 gastos',
+        'image': 'https://lh3.googleusercontent.com/aida-public/AB6AXuBoXwL6o57sQflYZ8hR9ioNd3N4R4qI8FKdI3I9PUwxEGSpuXcqULy3jTInPZvWOEQA-S5VZSAhbG1Yr2AkWinetGWItI1gfV107sNBYrzxQgKmYcQSgNA9KKPjILmEznZtJL1NO2JHW8zGDyrOJmeURB9xjGyAQMrgHsz5JfMXlv7HLk7skjMew9QXnuUPxfQ73zGnB9xY5I4sSJu0JInqbO63B1yARLiL_bqm4aQp_6b1A_1f4JuE-UTIm0KHZLddMZASPVIeCUsk',
+      },
+      {
+        'title': 'Alquiler de casa',
+        'members': '4 miembros, 20 gastos',
+        'image': 'https://lh3.googleusercontent.com/aida-public/AB6AXuCFPRUBEYIng5qXViFJzHgDr3vsHFeIamjj3ZWmWhYy5JrKodAi92Kt8zJF4PCxS26NaTTOTdh1Glav2ULCAF4G6Ht2HLBLmRZyoEJS1kja7lvLgO7_wFz28ByZ9Oh1p8hPCgJENIk23N674vp8JXU3NSJyF3hzj3Jrm31lIGYaWyj7UkmuuK5Md1aG7ONjMoDmPx8QfyRhNVa3z-W-Ws64S9cKigDlevnrpCMhM_O84JbTV78FYvv9ld7VS730Gsj3PYO7BuKU4m1V',
+      },
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Stitch AI'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {},
+          ),
+        ],
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: groups.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (context, i) {
+          final g = groups[i];
+          return ListTile(
+            contentPadding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            tileColor: lightGray,
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16)),
+            leading: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Image.network(g['image']!,
+                  width: 56, height: 56, fit: BoxFit.cover),
+            ),
+            title: Text(g['title']!,
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            subtitle: Text(g['members']!),
+            trailing: const Icon(Icons.chevron_right, color: blueishGray),
+            onTap: () {},
+          );
+        },
+      ),
+      bottomNavigationBar: const BottomNavigationBar(
+        currentIndex: 0,
+        items: [
+          BottomNavigationBarItem(icon: Icon(Icons.groups), label: 'Grupos'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.bar_chart), label: 'Dashboard'),
+          BottomNavigationBarItem(icon: Icon(Icons.payments), label: 'Pagos'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/ui/prototypes/login_page.dart
+++ b/lib/ui/prototypes/login_page.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+const lightSage = Color(0xFFF0F2F0);
+const warmGray = Color(0xFFEAEAEA);
+const lightGray = Color(0xFFD1D5DB);
+const blueishGray = Color(0xFF6B7280);
+const accentColor = Color(0xFFA78BFA);
+const textPrimary = Color(0xFF1F2937);
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: lightSage,
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.star, size: 64, color: accentColor),
+              const SizedBox(height: 16),
+              const Text('Stitch AI',
+                  style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 4),
+              const Text('Shared expenses, simplified.',
+                  style: TextStyle(color: blueishGray)),
+              const SizedBox(height: 32),
+              TextField(
+                decoration: InputDecoration(
+                  hintText: 'Email',
+                  filled: true,
+                  fillColor: warmGray,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: lightGray),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                obscureText: true,
+                decoration: InputDecoration(
+                  hintText: 'Password',
+                  filled: true,
+                  fillColor: warmGray,
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(12),
+                    borderSide: const BorderSide(color: lightGray),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: accentColor,
+                  shape: const StadiumBorder(),
+                  minimumSize: const Size.fromHeight(56),
+                ),
+                onPressed: () {},
+                child: const Text('Log In',
+                    style:
+                        TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              ),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: () {},
+                child: const Text.rich(
+                  TextSpan(
+                    text: "Don't have an account? ",
+                    style: TextStyle(color: blueishGray),
+                    children: [
+                      TextSpan(
+                        text: 'Sign up',
+                        style: TextStyle(
+                            color: accentColor, fontWeight: FontWeight.w600),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/prototypes/payments_page.dart
+++ b/lib/ui/prototypes/payments_page.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+class PaymentsPage extends StatelessWidget {
+  const PaymentsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pagos')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const SectionTitle('Tus deudas'),
+          _debtRow('Maria', 'Debes 12,50 €', true),
+          _debtRow('Juan', 'Debes 25,00 €', true),
+          const SectionTitle('Pagos realizados'),
+          _debtRow('Maria', 'Pagaste 12,50 €', false),
+          _debtRow('Juan', 'Pagaste 25,00 €', false),
+          const SectionTitle('Pagos por aprobar'),
+          _approveCard('Maria', 12.50),
+          _approveCard('Juan', 25.00),
+        ],
+      ),
+      bottomNavigationBar: BottomAppBar(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            const Spacer(),
+            ElevatedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.add),
+              label: const Text('Nuevo pago'),
+              style: ElevatedButton.styleFrom(shape: const StadiumBorder()),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static Widget _debtRow(String name, String text, bool pending) {
+    final color = pending ? Colors.amber[100] : Colors.green[100];
+    final label = pending ? 'Pendiente' : 'Pagado';
+    final labelColor = pending ? Colors.amber[700] : Colors.green[700];
+    return ListTile(
+      leading: const CircleAvatar(),
+      title: Text('A $name'),
+      subtitle: Text(text),
+      trailing: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration:
+            BoxDecoration(color: color, borderRadius: BorderRadius.circular(12)),
+        child: Text(label, style: TextStyle(color: labelColor, fontSize: 12)),
+      ),
+    );
+  }
+
+  static Widget _approveCard(String name, double amount) {
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const CircleAvatar(),
+                const SizedBox(width: 12),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('$name te pagó'),
+                    Text('${amount.toStringAsFixed(2)} €',
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 18)),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () {},
+                    child: const Text('Rechazar'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    child: const Text('Aprobar'),
+                  ),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SectionTitle extends StatelessWidget {
+  final String text;
+  const SectionTitle(this.text, {super.key});
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 24, bottom: 8),
+      child: Text(text,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Flutter prototype screens for login, groups, group detail, add expense, dashboard, and payments

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7b5c714e48324a484ae8814d791de