### PR TITLE
Add API service endpoints for groups, expenses, invitations, payments and notifications

### DIFF
--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -1,6 +1,54 @@
+import "package:dio/dio.dart";
+
+import "../models/expense.dart";
 import "../services/api_client.dart";
 
 class ExpenseService {
   final ApiClient _client;
   ExpenseService(this._client);
+
+  Future<List<Expense>> getExpenses(String groupId) async {
+    try {
+      final res = await _client.get("/groups/$groupId/expenses");
+      final data = res.data as List;
+      return data.map((e) => Expense.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Expense> createExpense(
+      String groupId, String description, double amount) async {
+    try {
+      final res = await _client.post("/expenses", data: {
+        "groupId": groupId,
+        "description": description,
+        "amount": amount,
+      });
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Expense> updateExpense(String id,
+      {String? description, double? amount}) async {
+    try {
+      final res = await _client.put("/expenses/$id", data: {
+        if (description != null) "description": description,
+        if (amount != null) "amount": amount,
+      });
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteExpense(String id) async {
+    try {
+      await _client.delete("/expenses/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
 }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,6 +1,54 @@
+import "package:dio/dio.dart";
+
+import "../models/group.dart";
 import "../services/api_client.dart";
 
 class GroupService {
   final ApiClient _client;
   GroupService(this._client);
+
+  Future<List<Group>> getGroups() async {
+    try {
+      final res = await _client.get("/groups");
+      final data = res.data as List;
+      return data.map((e) => Group.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Group> getGroup(String id) async {
+    try {
+      final res = await _client.get("/groups/$id");
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Group> createGroup(String name) async {
+    try {
+      final res = await _client.post("/groups", data: {"name": name});
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Group> updateGroup(String id, {required String name}) async {
+    try {
+      final res = await _client.put("/groups/$id", data: {"name": name});
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteGroup(String id) async {
+    try {
+      await _client.delete("/groups/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
 }

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,6 +1,38 @@
+import "package:dio/dio.dart";
+
 import "../services/api_client.dart";
 
 class InvitationService {
   final ApiClient _client;
   InvitationService(this._client);
+
+  Future<List<dynamic>> getInvitations() async {
+    try {
+      final res = await _client.get("/invitations");
+      return List<dynamic>.from(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> sendInvitation(String groupId, String email) async {
+    try {
+      await _client.post("/invitations", data: {
+        "groupId": groupId,
+        "email": email,
+      });
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> respondInvitation(String id, bool accept) async {
+    try {
+      await _client.post("/invitations/$id/respond", data: {
+        "accept": accept,
+      });
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,33 @@
+import "package:dio/dio.dart";
+
 import "../services/api_client.dart";
 
 class NotificationService {
   final ApiClient _client;
   NotificationService(this._client);
+
+  Future<List<dynamic>> getNotifications() async {
+    try {
+      final res = await _client.get("/notifications");
+      return List<dynamic>.from(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> markAsRead(String id) async {
+    try {
+      await _client.post("/notifications/$id/read");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteNotification(String id) async {
+    try {
+      await _client.delete("/notifications/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
 }

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,6 +1,38 @@
+import "package:dio/dio.dart";
+
 import "../services/api_client.dart";
 
 class PaymentService {
   final ApiClient _client;
   PaymentService(this._client);
+
+  Future<List<dynamic>> getPayments(String expenseId) async {
+    try {
+      final res = await _client.get("/expenses/$expenseId/payments");
+      return List<dynamic>.from(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> createPayment(
+      String expenseId, double amount, String payerId) async {
+    try {
+      await _client.post("/payments", data: {
+        "expenseId": expenseId,
+        "amount": amount,
+        "payerId": payerId,
+      });
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deletePayment(String id) async {
+    try {
+      await _client.delete("/payments/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- implement CRUD methods for groups
- add expense management functions
- support invitations, payments and notifications endpoints

## Testing
- `dart format lib/services/group_service.dart lib/services/expense_service.dart lib/services/invitation_service.dart lib/services/payment_service.dart lib/services/notification_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd6dce188324b81ad889a96a63c0