### PR TITLE
refactor: delegate repositories to services

### DIFF
--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,30 +1,16 @@
-
 import '../models/expense.dart';
+import '../services/expense_service.dart';
 
 class ExpenseRepository {
-  final List<Expense> _expenses = [];
+  final ExpenseService _service;
+  ExpenseRepository(this._service);
 
-  Future<List<Expense>> fetchExpenses(String groupId) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.where((e) => e.groupId == groupId).toList();
-  }
+  Future<List<Expense>> fetchExpenses(String groupId) =>
+      _service.fetchExpenses(groupId);
 
-  Future<Expense> getExpense(String id) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.firstWhere((e) => e.id == id);
-  }
+  Future<Expense> getExpense(String id) => _service.getExpense(id);
 
   Future<Expense> addExpense(
-      String groupId, String description, double amount) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final expense = Expense(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      groupId: groupId,
-      description: description,
-      amount: amount,
-    );
-    _expenses.add(expense);
-    return expense;
-  }
-=======
-
+          String groupId, String description, double amount) =>
+      _service.addExpense(groupId, description, amount);
+}

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -6,11 +6,17 @@ class ExpenseRepository {
   ExpenseRepository(this._service);
 
   Future<List<Expense>> fetchExpenses(String groupId) =>
-      _service.fetchExpenses(groupId);
+      _service.getExpenses(groupId);
 
   Future<Expense> getExpense(String id) => _service.getExpense(id);
 
   Future<Expense> addExpense(
           String groupId, String description, double amount) =>
-      _service.addExpense(groupId, description, amount);
+      _service.createExpense(groupId, description, amount);
+
+  Future<Expense> updateExpense(String id,
+          {String? description, double? amount}) =>
+      _service.updateExpense(id, description: description, amount: amount);
+
+  Future<void> deleteExpense(String id) => _service.deleteExpense(id);
 }

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,6 +1,8 @@
 import '../models/expense.dart';
 import '../services/expense_service.dart';
 
+/// Provides an abstraction over [ExpenseService] for fetching and
+/// mutating expense data.
 class ExpenseRepository {
   final ExpenseService _service;
   ExpenseRepository(this._service);

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,25 +1,14 @@
 
 import '../models/group.dart';
+import '../services/group_service.dart';
 
 class GroupRepository {
-  final List<Group> _groups = [];
+  final GroupService _service;
+  GroupRepository(this._service);
 
-  Future<List<Group>> fetchGroups() async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return [..._groups];
-  }
+  Future<List<Group>> fetchGroups() => _service.fetchGroups();
 
-  Future<Group> getGroup(String id) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _groups.firstWhere((g) => g.id == id);
-  }
+  Future<Group> getGroup(String id) => _service.getGroup(id);
 
-  Future<Group> addGroup(String name) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final group =
-        Group(id: DateTime.now().millisecondsSinceEpoch.toString(), name: name);
-    _groups.add(group);
-    return group;
-  }
-
+  Future<Group> addGroup(String name) => _service.addGroup(name);
 }

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -6,9 +6,14 @@ class GroupRepository {
   final GroupService _service;
   GroupRepository(this._service);
 
-  Future<List<Group>> fetchGroups() => _service.fetchGroups();
+  Future<List<Group>> fetchGroups() => _service.getGroups();
 
   Future<Group> getGroup(String id) => _service.getGroup(id);
 
-  Future<Group> addGroup(String name) => _service.addGroup(name);
+  Future<Group> addGroup(String name) => _service.createGroup(name);
+
+  Future<Group> updateGroup(String id, {required String name}) =>
+      _service.updateGroup(id, name: name);
+
+  Future<void> deleteGroup(String id) => _service.deleteGroup(id);
 }

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,7 +1,8 @@
-
 import '../models/group.dart';
 import '../services/group_service.dart';
 
+/// Provides an abstraction over [GroupService] for retrieving and
+/// managing groups.
 class GroupRepository {
   final GroupService _service;
   GroupRepository(this._service);

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -3,6 +3,7 @@ import "package:dio/dio.dart";
 import "../models/expense.dart";
 import "../services/api_client.dart";
 
+/// Handles all expense-related network requests.
 class ExpenseService {
   final ApiClient _client;
   ExpenseService(this._client);

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -1,6 +1,30 @@
+import "../models/expense.dart";
 import "../services/api_client.dart";
 
 class ExpenseService {
   final ApiClient _client;
   ExpenseService(this._client);
+
+  Future<List<Expense>> fetchExpenses(String groupId) async {
+    final res =
+        await _client.get<List<dynamic>>("/groups/$groupId/expenses");
+    final data = res.data ?? [];
+    return data
+        .map((e) => Expense.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Expense> getExpense(String id) async {
+    final res = await _client.get<Map<String, dynamic>>("/expenses/$id");
+    return Expense.fromJson(res.data!);
+  }
+
+  Future<Expense> addExpense(
+      String groupId, String description, double amount) async {
+    final res = await _client.post<Map<String, dynamic>>(
+      "/groups/$groupId/expenses",
+      data: {"description": description, "amount": amount},
+    );
+    return Expense.fromJson(res.data!);
+  }
 }

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -1,3 +1,5 @@
+import "package:dio/dio.dart";
+
 import "../models/expense.dart";
 import "../services/api_client.dart";
 
@@ -5,26 +7,57 @@ class ExpenseService {
   final ApiClient _client;
   ExpenseService(this._client);
 
-  Future<List<Expense>> fetchExpenses(String groupId) async {
-    final res =
-        await _client.get<List<dynamic>>("/groups/$groupId/expenses");
-    final data = res.data ?? [];
-    return data
-        .map((e) => Expense.fromJson(e as Map<String, dynamic>))
-        .toList();
+  Future<List<Expense>> getExpenses(String groupId) async {
+    try {
+      final res = await _client.get("/groups/$groupId/expenses");
+      final data = res.data as List;
+      return data.map((e) => Expense.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 
   Future<Expense> getExpense(String id) async {
-    final res = await _client.get<Map<String, dynamic>>("/expenses/$id");
-    return Expense.fromJson(res.data!);
+    try {
+      final res = await _client.get("/expenses/$id");
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 
-  Future<Expense> addExpense(
+  Future<Expense> createExpense(
       String groupId, String description, double amount) async {
-    final res = await _client.post<Map<String, dynamic>>(
-      "/groups/$groupId/expenses",
-      data: {"description": description, "amount": amount},
-    );
-    return Expense.fromJson(res.data!);
+    try {
+      final res = await _client.post("/expenses", data: {
+        "groupId": groupId,
+        "description": description,
+        "amount": amount,
+      });
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Expense> updateExpense(String id,
+      {String? description, double? amount}) async {
+    try {
+      final res = await _client.put("/expenses/$id", data: {
+        if (description != null) "description": description,
+        if (amount != null) "amount": amount,
+      });
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteExpense(String id) async {
+    try {
+      await _client.delete("/expenses/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,6 +1,26 @@
+import "../models/group.dart";
 import "../services/api_client.dart";
 
 class GroupService {
   final ApiClient _client;
   GroupService(this._client);
+
+  Future<List<Group>> fetchGroups() async {
+    final res = await _client.get<List<dynamic>>("/groups");
+    final data = res.data ?? [];
+    return data
+        .map((g) => Group.fromJson(g as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Group> getGroup(String id) async {
+    final res = await _client.get<Map<String, dynamic>>("/groups/$id");
+    return Group.fromJson(res.data!);
+  }
+
+  Future<Group> addGroup(String name) async {
+    final res = await _client.post<Map<String, dynamic>>("/groups",
+        data: {"name": name});
+    return Group.fromJson(res.data!);
+  }
 }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,3 +1,5 @@
+import "package:dio/dio.dart";
+
 import "../models/group.dart";
 import "../services/api_client.dart";
 
@@ -5,22 +7,48 @@ class GroupService {
   final ApiClient _client;
   GroupService(this._client);
 
-  Future<List<Group>> fetchGroups() async {
-    final res = await _client.get<List<dynamic>>("/groups");
-    final data = res.data ?? [];
-    return data
-        .map((g) => Group.fromJson(g as Map<String, dynamic>))
-        .toList();
+  Future<List<Group>> getGroups() async {
+    try {
+      final res = await _client.get("/groups");
+      final data = res.data as List;
+      return data.map((e) => Group.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 
   Future<Group> getGroup(String id) async {
-    final res = await _client.get<Map<String, dynamic>>("/groups/$id");
-    return Group.fromJson(res.data!);
+    try {
+      final res = await _client.get("/groups/$id");
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 
-  Future<Group> addGroup(String name) async {
-    final res = await _client.post<Map<String, dynamic>>("/groups",
-        data: {"name": name});
-    return Group.fromJson(res.data!);
+  Future<Group> createGroup(String name) async {
+    try {
+      final res = await _client.post("/groups", data: {"name": name});
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Group> updateGroup(String id, {required String name}) async {
+    try {
+      final res = await _client.put("/groups/$id", data: {"name": name});
+      return Group.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteGroup(String id) async {
+    try {
+      await _client.delete("/groups/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- refactor GroupRepository to delegate to GroupService
- refactor ExpenseRepository to use ExpenseService and fix class
- implement GroupService and ExpenseService methods to call ApiClient

## Testing
- `dart format lib/repositories/group_repository.dart lib/repositories/expense_repository.dart lib/services/group_service.dart lib/services/expense_service.dart` *(fails: command not found)*
- `flutter format lib/repositories/group_repository.dart lib/repositories/expense_repository.dart lib/services/group_service.dart lib/services/expense_service.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd74dc3c832495213572a8b1884e