### PR TITLE
feat: add model serialization for core entities

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -3,12 +3,16 @@ class Expense {
   final String groupId;
   final String description;
   final double amount;
+  final String? createdBy;
+  final DateTime? createdAt;
 
   Expense({
     required this.id,
     required this.groupId,
     required this.description,
     required this.amount,
+    this.createdBy,
+    this.createdAt,
   });
 
   factory Expense.fromJson(Map<String, dynamic> json) => Expense(
@@ -16,6 +20,10 @@ class Expense {
         groupId: json['groupId'].toString(),
         description: json['description'] ?? '',
         amount: (json['amount'] as num?)?.toDouble() ?? 0,
+        createdBy: json['createdBy']?.toString(),
+        createdAt: json['createdAt'] != null
+            ? DateTime.parse(json['createdAt'])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -23,5 +31,7 @@ class Expense {
         'groupId': groupId,
         'description': description,
         'amount': amount,
+        'createdBy': createdBy,
+        'createdAt': createdAt?.toIso8601String(),
       };
 }

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -1,16 +1,23 @@
 class Group {
   final String id;
   final String name;
+  final String? description;
+  final DateTime? createdAt;
 
-  Group({required this.id, required this.name});
+  Group({required this.id, required this.name, this.description, this.createdAt});
 
   factory Group.fromJson(Map<String, dynamic> json) => Group(
         id: json['id'].toString(),
         name: json['name'] ?? '',
+        description: json['description'],
+        createdAt:
+            json['createdAt'] != null ? DateTime.parse(json['createdAt']) : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
+        'description': description,
+        'createdAt': createdAt?.toIso8601String(),
       };
 }

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -1,1 +1,38 @@
+class Invitation {
+  final String id;
+  final String groupId;
+  final String email;
+  final String status;
+  final String? invitedBy;
+  final DateTime? createdAt;
+
+  Invitation({
+    required this.id,
+    required this.groupId,
+    required this.email,
+    required this.status,
+    this.invitedBy,
+    this.createdAt,
+  });
+
+  factory Invitation.fromJson(Map<String, dynamic> json) => Invitation(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        email: json['email'] ?? '',
+        status: json['status'] ?? '',
+        invitedBy: json['invitedBy']?.toString(),
+        createdAt: json['createdAt'] != null
+            ? DateTime.parse(json['createdAt'])
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'email': email,
+        'status': status,
+        'invitedBy': invitedBy,
+        'createdAt': createdAt?.toIso8601String(),
+      };
+}
 

--- a/lib/models/payment.dart
+++ b/lib/models/payment.dart
@@ -1,1 +1,42 @@
+class Payment {
+  final String id;
+  final String groupId;
+  final String fromUserId;
+  final String toUserId;
+  final double amount;
+  final String status;
+  final DateTime? createdAt;
+
+  Payment({
+    required this.id,
+    required this.groupId,
+    required this.fromUserId,
+    required this.toUserId,
+    required this.amount,
+    required this.status,
+    this.createdAt,
+  });
+
+  factory Payment.fromJson(Map<String, dynamic> json) => Payment(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        fromUserId: json['fromUserId'].toString(),
+        toUserId: json['toUserId'].toString(),
+        amount: (json['amount'] as num?)?.toDouble() ?? 0,
+        status: json['status'] ?? '',
+        createdAt: json['createdAt'] != null
+            ? DateTime.parse(json['createdAt'])
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'fromUserId': fromUserId,
+        'toUserId': toUserId,
+        'amount': amount,
+        'status': status,
+        'createdAt': createdAt?.toIso8601String(),
+      };
+}
 

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -2,18 +2,21 @@ class User {
   final String id;
   final String email;
   final String? name;
+  final String? avatarUrl;
 
-  User({required this.id, required this.email, this.name});
+  User({required this.id, required this.email, this.name, this.avatarUrl});
 
   factory User.fromJson(Map<String, dynamic> json) => User(
         id: json["id"].toString(),
         email: json["email"] ?? "",
         name: json["name"],
+        avatarUrl: json["avatarUrl"],
       );
 
   Map<String, dynamic> toJson() => {
         "id": id,
         "email": email,
         "name": name,
+        "avatarUrl": avatarUrl,
       };
 }

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,4 +1,3 @@
-
 import '../models/expense.dart';
 
 class ExpenseRepository {
@@ -22,9 +21,10 @@ class ExpenseRepository {
       groupId: groupId,
       description: description,
       amount: amount,
+      createdAt: DateTime.now(),
     );
     _expenses.add(expense);
     return expense;
   }
-=======
+}
 

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -14,10 +14,14 @@ class GroupRepository {
     return _groups.firstWhere((g) => g.id == id);
   }
 
-  Future<Group> addGroup(String name) async {
+  Future<Group> addGroup(String name, {String? description}) async {
     await Future.delayed(const Duration(milliseconds: 200));
-    final group =
-        Group(id: DateTime.now().millisecondsSinceEpoch.toString(), name: name);
+    final group = Group(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      name: name,
+      description: description,
+      createdAt: DateTime.now(),
+    );
     _groups.add(group);
     return group;
   }

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -23,10 +23,10 @@ class GroupNotifier extends StateNotifier<GroupState> {
     }
   }
 
-  Future<void> addGroup(String name) async {
+  Future<void> addGroup(String name, {String? description}) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      await _repo.addGroup(name);
+      await _repo.addGroup(name, description: description);
       final groups = await _repo.fetchGroups();
       state = state.copyWith(groups: groups, isLoading: false);
     } catch (e) {


### PR DESCRIPTION
## Summary
- add fields and fromJson/toJson to expense model
- create invitation and payment models
- expand user and group models and repositories

## Testing
- `dart format lib/models/expense.dart lib/models/invitation.dart lib/models/payment.dart lib/models/user.dart lib/models/group.dart lib/repositories/expense_repository.dart lib/repositories/group_repository.dart lib/state/groups/group_provider.dart` *(command not found)*
- `flutter --version` *(command not found)*
- `dart test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd80a9188324a6f3fd432a23fd9a