### PR TITLE
Handle API errors and loading states for groups and expenses

### DIFF
--- a/lib/state/expenses/expense_provider.dart
+++ b/lib/state/expenses/expense_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
 import '../../config/locator.dart';
 import '../../repositories/expense_repository.dart';
 import '../../models/expense.dart';
@@ -18,6 +19,9 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
     try {
       final expenses = await _repo.fetchExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }
@@ -30,6 +34,9 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
       await _repo.addExpense(groupId, description, amount);
       final expenses = await _repo.fetchExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
 import '../../config/locator.dart';
 import '../../repositories/group_repository.dart';
 import '../../models/group.dart';
@@ -18,6 +19,9 @@ class GroupNotifier extends StateNotifier<GroupState> {
     try {
       final groups = await _repo.fetchGroups();
       state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }
@@ -29,6 +33,9 @@ class GroupNotifier extends StateNotifier<GroupState> {
       await _repo.addGroup(name);
       final groups = await _repo.fetchGroups();
       state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }

--- a/lib/ui/screens/expenses/expense_form_screen.dart
+++ b/lib/ui/screens/expenses/expense_form_screen.dart
@@ -12,6 +12,7 @@ class ExpenseFormScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final descController = useTextEditingController();
     final amountController = useTextEditingController();
+    final state = ref.watch(expenseNotifierProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Nuevo Gasto')),
@@ -30,17 +31,27 @@ class ExpenseFormScreen extends HookConsumerWidget {
                   const TextInputType.numberWithOptions(decimal: true),
             ),
             const SizedBox(height: 20),
+            if (state.error != null) ...[
+              Text(state.error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 20),
+            ],
             ElevatedButton(
-              onPressed: () async {
-                final amount = double.tryParse(amountController.text) ?? 0;
-                await ref
-                    .read(expenseNotifierProvider.notifier)
-                    .addExpense(groupId, descController.text, amount);
-                if (context.mounted) {
-                  context.pop();
-                }
-              },
-              child: const Text('Guardar'),
+              onPressed: state.isLoading
+                  ? null
+                  : () async {
+                      final amount =
+                          double.tryParse(amountController.text) ?? 0;
+                      await ref
+                          .read(expenseNotifierProvider.notifier)
+                          .addExpense(groupId, descController.text, amount);
+                      final error = ref.read(expenseNotifierProvider).error;
+                      if (context.mounted && error == null) {
+                        context.pop();
+                      }
+                    },
+              child: state.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Guardar'),
             ),
           ],
         ),

--- a/lib/ui/screens/expenses/expense_list_screen.dart
+++ b/lib/ui/screens/expenses/expense_list_screen.dart
@@ -21,18 +21,20 @@ class ExpenseListScreen extends HookConsumerWidget {
       appBar: AppBar(title: const Text('Gastos')),
       body: state.isLoading
           ? const Center(child: CircularProgressIndicator())
-          : ListView.builder(
-              itemCount: state.expenses.length,
-              itemBuilder: (_, index) {
-                final expense = state.expenses[index];
-                return ListTile(
-                  title: Text(expense.description),
-                  subtitle: Text('\\$${expense.amount.toStringAsFixed(2)}'),
-                  onTap: () =>
-                      context.push('/groups/$groupId/expenses/${expense.id}'),
-                );
-              },
-            ),
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: state.expenses.length,
+                  itemBuilder: (_, index) {
+                    final expense = state.expenses[index];
+                    return ListTile(
+                      title: Text(expense.description),
+                      subtitle: Text('\\$${expense.amount.toStringAsFixed(2)}'),
+                      onTap: () =>
+                          context.push('/groups/$groupId/expenses/${expense.id}'),
+                    );
+                  },
+                ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.push('/groups/$groupId/expenses/new'),
         child: const Icon(Icons.add),

--- a/lib/ui/screens/groups/group_form_screen.dart
+++ b/lib/ui/screens/groups/group_form_screen.dart
@@ -10,6 +10,7 @@ class GroupFormScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nameController = useTextEditingController();
+    final state = ref.watch(groupNotifierProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Nuevo Grupo')),
@@ -22,16 +23,25 @@ class GroupFormScreen extends HookConsumerWidget {
               decoration: const InputDecoration(labelText: 'Nombre'),
             ),
             const SizedBox(height: 20),
+            if (state.error != null) ...[
+              Text(state.error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 20),
+            ],
             ElevatedButton(
-              onPressed: () async {
-                await ref
-                    .read(groupNotifierProvider.notifier)
-                    .addGroup(nameController.text);
-                if (context.mounted) {
-                  context.pop();
-                }
-              },
-              child: const Text('Guardar'),
+              onPressed: state.isLoading
+                  ? null
+                  : () async {
+                      await ref
+                          .read(groupNotifierProvider.notifier)
+                          .addGroup(nameController.text);
+                      final error = ref.read(groupNotifierProvider).error;
+                      if (context.mounted && error == null) {
+                        context.pop();
+                      }
+                    },
+              child: state.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Guardar'),
             ),
           ],
         ),

--- a/lib/ui/screens/groups/group_list_screen.dart
+++ b/lib/ui/screens/groups/group_list_screen.dart
@@ -20,16 +20,18 @@ class GroupListScreen extends HookConsumerWidget {
       appBar: AppBar(title: const Text('Grupos')),
       body: state.isLoading
           ? const Center(child: CircularProgressIndicator())
-          : ListView.builder(
-              itemCount: state.groups.length,
-              itemBuilder: (_, index) {
-                final group = state.groups[index];
-                return ListTile(
-                  title: Text(group.name),
-                  onTap: () => context.push('/groups/${group.id}'),
-                );
-              },
-            ),
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: state.groups.length,
+                  itemBuilder: (_, index) {
+                    final group = state.groups[index];
+                    return ListTile(
+                      title: Text(group.name),
+                      onTap: () => context.push('/groups/${group.id}'),
+                    );
+                  },
+                ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.push('/groups/new'),
         child: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- handle HTTP errors in group and expense notifiers
- show loading and error states on group and expense screens

## Testing
- `flutter analyze` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository not signed)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd8912e88324bcbfe1c423913c87