### PR TITLE
feat: add auth error interceptors

### DIFF
--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,26 +1,32 @@
 import "package:dio/dio.dart";
+
 import "../config/env.dart";
-import "../repositories/auth_repository.dart";
 import "../config/locator.dart";
+import "../repositories/auth_repository.dart";
 
 class ApiClient {
   final Dio _dio;
 
   ApiClient(this._dio) {
     _dio.options.baseUrl = Env.apiBaseUrl;
-    _dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (options, handler) async {
-        final token = await locator<AuthRepository>().getToken();
-        if (token != null && token.isNotEmpty) {
-          options.headers["Authorization"] = "Bearer $token";
-        }
-        return handler.next(options);
-      },
-      onError: (e, handler) {
-        // Puedes centralizar manejo de 401/500 aquí
-        return handler.next(e);
-      },
-    ));
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await locator<AuthRepository>().getToken();
+          if (token != null && token.isNotEmpty) {
+            options.headers["Authorization"] = "Bearer $token";
+          }
+          return handler.next(options);
+        },
+        onError: (e, handler) async {
+          if (e.response?.statusCode == 401) {
+            await locator<AuthRepository>().logout();
+          }
+          final message = _mapError(e);
+          return handler.reject(e.copyWith(message: message));
+        },
+      ),
+    );
   }
 
   Future<Response<T>> get<T>(String path, {Map<String, dynamic>? query}) =>
@@ -34,4 +40,31 @@ class ApiClient {
 
   Future<Response<T>> delete<T>(String path) =>
       _dio.delete(path);
+
+  static String _mapError(DioException e) {
+    if (e.type == DioExceptionType.connectionTimeout ||
+        e.type == DioExceptionType.sendTimeout ||
+        e.type == DioExceptionType.receiveTimeout) {
+      return "Tiempo de conexión agotado. Intenta nuevamente.";
+    }
+
+    if (e.type == DioExceptionType.connectionError) {
+      return "Error de conexión. Verifica tu red.";
+    }
+
+    switch (e.response?.statusCode) {
+      case 400:
+        return "Solicitud inválida.";
+      case 401:
+        return "Sesión expirada. Inicia sesión nuevamente.";
+      case 403:
+        return "No autorizado.";
+      case 404:
+        return "Recurso no encontrado.";
+      case 500:
+        return "Error interno del servidor.";
+      default:
+        return "Ocurrió un error inesperado.";
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- handle 401 responses by logging out
- map network/server errors to user-friendly messages

## Testing
- `dart format lib/services/api_client.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd94e0048324bc6a23acc428c348