### PR TITLE
Refactor repositories to use services

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -32,8 +32,10 @@ Future<void> setupLocator() async {
 
   // Repositories
   locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
-  locator.registerLazySingleton<GroupRepository>(() => GroupRepository());
-  locator.registerLazySingleton<ExpenseRepository>(() => ExpenseRepository());
+  locator.registerLazySingleton<GroupRepository>(
+      () => GroupRepository(locator<GroupService>()));
+  locator.registerLazySingleton<ExpenseRepository>(
+      () => ExpenseRepository(locator<ExpenseService>()));
   locator.registerLazySingleton<InvitationRepository>(() => InvitationRepository(locator<InvitationService>()));
   locator.registerLazySingleton<PaymentRepository>(() => PaymentRepository(locator<PaymentService>()));
   locator.registerLazySingleton<NotificationRepository>(() => NotificationRepository(locator<NotificationService>()));

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,30 +1,28 @@
 import '../models/expense.dart';
+import '../services/expense_service.dart';
 
 class ExpenseRepository {
-  final List<Expense> _expenses = [];
+  final ExpenseService _service;
 
-  Future<List<Expense>> fetchExpenses(String groupId) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.where((e) => e.groupId == groupId).toList();
+  ExpenseRepository(this._service);
+
+  Future<List<Expense>> getExpenses(String groupId) async {
+    return _service.getExpenses(groupId);
   }
 
-  Future<Expense> getExpense(String id) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.firstWhere((e) => e.id == id);
-  }
-
-  Future<Expense> addExpense(
+  Future<Expense> createExpense(
       String groupId, String description, double amount) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final expense = Expense(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      groupId: groupId,
-      description: description,
-      amount: amount,
-      createdAt: DateTime.now(),
-    );
-    _expenses.add(expense);
-    return expense;
+    return _service.createExpense(groupId, description, amount);
+  }
+
+  Future<Expense> updateExpense(String id,
+      {String? description, double? amount}) async {
+    return _service.updateExpense(id,
+        description: description, amount: amount);
+  }
+
+  Future<void> deleteExpense(String id) async {
+    await _service.deleteExpense(id);
   }
 }
 

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,29 +1,29 @@
 
 import '../models/group.dart';
+import '../services/group_service.dart';
 
 class GroupRepository {
-  final List<Group> _groups = [];
+  final GroupService _service;
 
-  Future<List<Group>> fetchGroups() async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return [..._groups];
+  GroupRepository(this._service);
+
+  Future<List<Group>> getGroups() async {
+    return _service.getGroups();
   }
 
   Future<Group> getGroup(String id) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _groups.firstWhere((g) => g.id == id);
+    return _service.getGroup(id);
   }
 
-  Future<Group> addGroup(String name, {String? description}) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final group = Group(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      name: name,
-      description: description,
-      createdAt: DateTime.now(),
-    );
-    _groups.add(group);
-    return group;
+  Future<Group> createGroup(String name) async {
+    return _service.createGroup(name);
   }
 
+  Future<Group> updateGroup(String id, {required String name}) async {
+    return _service.updateGroup(id, name: name);
+  }
+
+  Future<void> deleteGroup(String id) async {
+    await _service.deleteGroup(id);
+  }
 }

--- a/lib/state/expenses/expense_provider.dart
+++ b/lib/state/expenses/expense_provider.dart
@@ -17,7 +17,7 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
   Future<void> fetchExpenses(String groupId) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final expenses = await _repo.fetchExpenses(groupId);
+      final expenses = await _repo.getExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(
@@ -31,8 +31,8 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
       String groupId, String description, double amount) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      await _repo.addExpense(groupId, description, amount);
-      final expenses = await _repo.fetchExpenses(groupId);
+      await _repo.createExpense(groupId, description, amount);
+      final expenses = await _repo.getExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -17,7 +17,7 @@ class GroupNotifier extends StateNotifier<GroupState> {
   Future<void> fetchGroups() async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final groups = await _repo.fetchGroups();
+      final groups = await _repo.getGroups();
       state = state.copyWith(groups: groups, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(
@@ -27,11 +27,11 @@ class GroupNotifier extends StateNotifier<GroupState> {
     }
   }
 
-  Future<void> addGroup(String name, {String? description}) async {
+  Future<void> addGroup(String name) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      await _repo.addGroup(name, description: description);
-      final groups = await _repo.fetchGroups();
+      await _repo.createGroup(name);
+      final groups = await _repo.getGroups();
       state = state.copyWith(groups: groups, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(


### PR DESCRIPTION
## Summary
- Delegate group operations to GroupService and expose CRUD methods
- Use ExpenseService in ExpenseRepository with full CRUD helpers
- Update state notifiers and locator to work with new repositories

## Testing
- ⚠️ `dart format lib/repositories/group_repository.dart lib/repositories/expense_repository.dart lib/state/groups/group_provider.dart lib/state/expenses/expense_provider.dart lib/config/locator.dart` *(command not found)*
- ⚠️ `dart analyze` *(command not found)*
- ⚠️ `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c78225988324af1054661a891cf7