### PR TITLE
Add missing fields to models and update services

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -5,6 +5,7 @@ class Expense {
   final double amount;
   final String? createdBy;
   final DateTime? createdAt;
+  final DateTime? updatedAt;
 
   Expense({
     required this.id,
@@ -13,6 +14,7 @@ class Expense {
     required this.amount,
     this.createdBy,
     this.createdAt,
+    this.updatedAt,
   });
 
   factory Expense.fromJson(Map<String, dynamic> json) => Expense(
@@ -24,6 +26,9 @@ class Expense {
         createdAt: json['createdAt'] != null
             ? DateTime.parse(json['createdAt'])
             : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.parse(json['updatedAt'])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -33,5 +38,6 @@ class Expense {
         'amount': amount,
         'createdBy': createdBy,
         'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
       };
 }

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -2,22 +2,36 @@ class Group {
   final String id;
   final String name;
   final String? description;
+  final String? createdBy;
   final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  Group({required this.id, required this.name, this.description, this.createdAt});
+  Group({
+    required this.id,
+    required this.name,
+    this.description,
+    this.createdBy,
+    this.createdAt,
+    this.updatedAt,
+  });
 
   factory Group.fromJson(Map<String, dynamic> json) => Group(
         id: json['id'].toString(),
         name: json['name'] ?? '',
         description: json['description'],
+        createdBy: json['createdBy']?.toString(),
         createdAt:
             json['createdAt'] != null ? DateTime.parse(json['createdAt']) : null,
+        updatedAt:
+            json['updatedAt'] != null ? DateTime.parse(json['updatedAt']) : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
         'description': description,
+        'createdBy': createdBy,
         'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
       };
 }

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -5,6 +5,7 @@ class Invitation {
   final String status;
   final String? invitedBy;
   final DateTime? createdAt;
+  final DateTime? updatedAt;
 
   Invitation({
     required this.id,
@@ -13,6 +14,7 @@ class Invitation {
     required this.status,
     this.invitedBy,
     this.createdAt,
+    this.updatedAt,
   });
 
   factory Invitation.fromJson(Map<String, dynamic> json) => Invitation(
@@ -24,6 +26,9 @@ class Invitation {
         createdAt: json['createdAt'] != null
             ? DateTime.parse(json['createdAt'])
             : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.parse(json['updatedAt'])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -33,6 +38,7 @@ class Invitation {
         'status': status,
         'invitedBy': invitedBy,
         'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
       };
 }
 

--- a/lib/models/payment.dart
+++ b/lib/models/payment.dart
@@ -6,6 +6,7 @@ class Payment {
   final double amount;
   final String status;
   final DateTime? createdAt;
+  final DateTime? updatedAt;
 
   Payment({
     required this.id,
@@ -15,6 +16,7 @@ class Payment {
     required this.amount,
     required this.status,
     this.createdAt,
+    this.updatedAt,
   });
 
   factory Payment.fromJson(Map<String, dynamic> json) => Payment(
@@ -27,6 +29,9 @@ class Payment {
         createdAt: json['createdAt'] != null
             ? DateTime.parse(json['createdAt'])
             : null,
+        updatedAt: json['updatedAt'] != null
+            ? DateTime.parse(json['updatedAt'])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -37,6 +42,7 @@ class Payment {
         'amount': amount,
         'status': status,
         'createdAt': createdAt?.toIso8601String(),
+        'updatedAt': updatedAt?.toIso8601String(),
       };
 }
 

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -3,14 +3,32 @@ class User {
   final String email;
   final String? name;
   final String? avatarUrl;
+  final String? phoneNumber;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
 
-  User({required this.id, required this.email, this.name, this.avatarUrl});
+  User({
+    required this.id,
+    required this.email,
+    this.name,
+    this.avatarUrl,
+    this.phoneNumber,
+    this.createdAt,
+    this.updatedAt,
+  });
 
   factory User.fromJson(Map<String, dynamic> json) => User(
         id: json["id"].toString(),
         email: json["email"] ?? "",
         name: json["name"],
-        avatarUrl: json["avatarUrl"],
+        avatarUrl: json["avatarUrl"] ?? json["profilePictureUrl"],
+        phoneNumber: json["phoneNumber"] ?? json["phone_number"],
+        createdAt: json["createdAt"] != null
+            ? DateTime.parse(json["createdAt"])
+            : null,
+        updatedAt: json["updatedAt"] != null
+            ? DateTime.parse(json["updatedAt"])
+            : null,
       );
 
   Map<String, dynamic> toJson() => {
@@ -18,5 +36,8 @@ class User {
         "email": email,
         "name": name,
         "avatarUrl": avatarUrl,
+        "phoneNumber": phoneNumber,
+        "createdAt": createdAt?.toIso8601String(),
+        "updatedAt": updatedAt?.toIso8601String(),
       };
 }

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -16,12 +16,14 @@ class ExpenseRepository {
   Future<Expense> addExpense(
       String groupId, String description, double amount) async {
     await Future.delayed(const Duration(milliseconds: 200));
+    final now = DateTime.now();
     final expense = Expense(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       groupId: groupId,
       description: description,
       amount: amount,
-      createdAt: DateTime.now(),
+      createdAt: now,
+      updatedAt: now,
     );
     _expenses.add(expense);
     return expense;

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,4 +1,5 @@
 import '../models/expense.dart';
+// In-memory repository for managing expenses.
 
 class ExpenseRepository {
   final List<Expense> _expenses = [];

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,4 +1,5 @@
 
+// In-memory repository for managing groups.
 import '../models/group.dart';
 
 class GroupRepository {

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -16,11 +16,13 @@ class GroupRepository {
 
   Future<Group> addGroup(String name, {String? description}) async {
     await Future.delayed(const Duration(milliseconds: 200));
+    final now = DateTime.now();
     final group = Group(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       name: name,
       description: description,
-      createdAt: DateTime.now(),
+      createdAt: now,
+      updatedAt: now,
     );
     _groups.add(group);
     return group;

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -1,26 +1,29 @@
 import "package:dio/dio.dart";
 
+import "../models/invitation.dart";
 import "../services/api_client.dart";
 
 class InvitationService {
   final ApiClient _client;
   InvitationService(this._client);
 
-  Future<List<dynamic>> getInvitations() async {
+  Future<List<Invitation>> getInvitations() async {
     try {
       final res = await _client.get("/invitations");
-      return List<dynamic>.from(res.data);
+      final data = res.data as List;
+      return data.map((e) => Invitation.fromJson(e)).toList();
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }
   }
 
-  Future<void> sendInvitation(String groupId, String email) async {
+  Future<Invitation> sendInvitation(String groupId, String email) async {
     try {
-      await _client.post("/invitations", data: {
+      final res = await _client.post("/invitations", data: {
         "groupId": groupId,
         "email": email,
       });
+      return Invitation.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,28 +1,31 @@
 import "package:dio/dio.dart";
 
+import "../models/payment.dart";
 import "../services/api_client.dart";
 
 class PaymentService {
   final ApiClient _client;
   PaymentService(this._client);
 
-  Future<List<dynamic>> getPayments(String expenseId) async {
+  Future<List<Payment>> getPayments(String expenseId) async {
     try {
       final res = await _client.get("/expenses/$expenseId/payments");
-      return List<dynamic>.from(res.data);
+      final data = res.data as List;
+      return data.map((e) => Payment.fromJson(e)).toList();
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }
   }
 
-  Future<void> createPayment(
+  Future<Payment> createPayment(
       String expenseId, double amount, String payerId) async {
     try {
-      await _client.post("/payments", data: {
+      final res = await _client.post("/payments", data: {
         "expenseId": expenseId,
         "amount": amount,
         "payerId": payerId,
       });
+      return Payment.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }


### PR DESCRIPTION
## Summary
- add `updatedAt` and other metadata fields to core models
- update in-memory repositories to populate new timestamps
- return typed `Invitation` and `Payment` models from services

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c78331988324b26bb5aae56b74b5