### PR TITLE
feat: adjust expense API and forms

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -33,7 +33,8 @@ Future<void> setupLocator() async {
   // Repositories
   locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
   locator.registerLazySingleton<GroupRepository>(() => GroupRepository());
-  locator.registerLazySingleton<ExpenseRepository>(() => ExpenseRepository());
+  locator.registerLazySingleton<ExpenseRepository>(
+      () => ExpenseRepository(locator<ExpenseService>()));
   locator.registerLazySingleton<InvitationRepository>(() => InvitationRepository(locator<InvitationService>()));
   locator.registerLazySingleton<PaymentRepository>(() => PaymentRepository(locator<PaymentService>()));
   locator.registerLazySingleton<NotificationRepository>(() => NotificationRepository(locator<NotificationService>()));

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -1,30 +1,25 @@
 import '../models/expense.dart';
+import '../services/expense_service.dart';
 
 class ExpenseRepository {
-  final List<Expense> _expenses = [];
+  final ExpenseService _service;
+  ExpenseRepository(this._service);
 
   Future<List<Expense>> fetchExpenses(String groupId) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.where((e) => e.groupId == groupId).toList();
-  }
-
-  Future<Expense> getExpense(String id) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    return _expenses.firstWhere((e) => e.id == id);
+    return _service.getExpenses(groupId);
   }
 
   Future<Expense> addExpense(
-      String groupId, String description, double amount) async {
-    await Future.delayed(const Duration(milliseconds: 200));
-    final expense = Expense(
-      id: DateTime.now().millisecondsSinceEpoch.toString(),
-      groupId: groupId,
-      description: description,
-      amount: amount,
-      createdAt: DateTime.now(),
-    );
-    _expenses.add(expense);
-    return expense;
+      String groupId, String description, double amount,
+      {String? createdBy}) async {
+    return _service.createExpense(groupId, description, amount,
+        createdBy: createdBy);
+  }
+
+  Future<Expense> updateExpense(String id, String groupId,
+      {String? description, double? amount}) async {
+    return _service.updateExpense(id, groupId,
+        description: description, amount: amount);
   }
 }
 

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -9,7 +9,8 @@ class ExpenseService {
 
   Future<List<Expense>> getExpenses(String groupId) async {
     try {
-      final res = await _client.get("/groups/$groupId/expenses");
+      final res =
+          await _client.get("/expenses", queryParameters: {"groupId": groupId});
       final data = res.data as List;
       return data.map((e) => Expense.fromJson(e)).toList();
     } on DioException catch (e) {
@@ -18,12 +19,14 @@ class ExpenseService {
   }
 
   Future<Expense> createExpense(
-      String groupId, String description, double amount) async {
+      String groupId, String description, double amount,
+      {String? createdBy}) async {
     try {
       final res = await _client.post("/expenses", data: {
         "groupId": groupId,
         "description": description,
         "amount": amount,
+        if (createdBy != null) "createdBy": createdBy,
       });
       return Expense.fromJson(res.data);
     } on DioException catch (e) {
@@ -31,13 +34,15 @@ class ExpenseService {
     }
   }
 
-  Future<Expense> updateExpense(String id,
+  Future<Expense> updateExpense(String id, String groupId,
       {String? description, double? amount}) async {
     try {
-      final res = await _client.put("/expenses/$id", data: {
-        if (description != null) "description": description,
-        if (amount != null) "amount": amount,
-      });
+      final res = await _client.put("/expenses/$id",
+          queryParameters: {"groupId": groupId},
+          data: {
+            if (description != null) "description": description,
+            if (amount != null) "amount": amount,
+          });
       return Expense.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);

--- a/lib/state/expenses/expense_provider.dart
+++ b/lib/state/expenses/expense_provider.dart
@@ -28,10 +28,12 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
   }
 
   Future<void> addExpense(
-      String groupId, String description, double amount) async {
+      String groupId, String description, double amount,
+      {String? createdBy}) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      await _repo.addExpense(groupId, description, amount);
+      await _repo.addExpense(groupId, description, amount,
+          createdBy: createdBy);
       final expenses = await _repo.fetchExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);
     } on DioException catch (e) {

--- a/lib/ui/screens/expenses/expense_form_screen.dart
+++ b/lib/ui/screens/expenses/expense_form_screen.dart
@@ -12,6 +12,7 @@ class ExpenseFormScreen extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final descController = useTextEditingController();
     final amountController = useTextEditingController();
+    final createdByController = useTextEditingController();
     final state = ref.watch(expenseNotifierProvider);
 
     return Scaffold(
@@ -30,6 +31,10 @@ class ExpenseFormScreen extends HookConsumerWidget {
               keyboardType:
                   const TextInputType.numberWithOptions(decimal: true),
             ),
+            TextField(
+              controller: createdByController,
+              decoration: const InputDecoration(labelText: 'Creado por'),
+            ),
             const SizedBox(height: 20),
             if (state.error != null) ...[
               Text(state.error!, style: const TextStyle(color: Colors.red)),
@@ -43,7 +48,8 @@ class ExpenseFormScreen extends HookConsumerWidget {
                           double.tryParse(amountController.text) ?? 0;
                       await ref
                           .read(expenseNotifierProvider.notifier)
-                          .addExpense(groupId, descController.text, amount);
+                          .addExpense(groupId, descController.text, amount,
+                              createdBy: createdByController.text);
                       final error = ref.read(expenseNotifierProvider).error;
                       if (context.mounted && error == null) {
                         context.pop();


### PR DESCRIPTION
## Summary
- use groupId query parameter for expense API
- allow specifying creator when creating expenses
- wire UI and repository to new service methods

## Testing
- `dart format lib/services/expense_service.dart lib/repositories/expense_repository.dart lib/state/expenses/expense_provider.dart lib/ui/screens/expenses/expense_form_screen.dart lib/config/locator.dart` *(fails: command not found)*
- `flutter format lib/services/expense_service.dart lib/repositories/expense_repository.dart lib/state/expenses/expense_provider.dart lib/ui/screens/expenses/expense_form_screen.dart lib/config/locator.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c78580748324bb73999740e25098