### PR TITLE
feat: expand expense fields and service filters

### DIFF
--- a/lib/models/expense.dart
+++ b/lib/models/expense.dart
@@ -3,6 +3,12 @@ class Expense {
   final String groupId;
   final String description;
   final double amount;
+  final double totalAmount;
+  final DateTime? expenseDate;
+  final bool hasTicket;
+  final String? ticketImageUrl;
+  final List<String> participants;
+  final String? status;
   final String? createdBy;
   final DateTime? createdAt;
   final DateTime? updatedAt;
@@ -11,7 +17,13 @@ class Expense {
     required this.id,
     required this.groupId,
     required this.description,
-    required this.amount,
+    this.amount = 0,
+    this.totalAmount = 0,
+    this.expenseDate,
+    this.hasTicket = false,
+    this.ticketImageUrl,
+    this.participants = const [],
+    this.status,
     this.createdBy,
     this.createdAt,
     this.updatedAt,
@@ -19,25 +31,42 @@ class Expense {
 
   factory Expense.fromJson(Map<String, dynamic> json) => Expense(
         id: json['id'].toString(),
-        groupId: json['groupId'].toString(),
+        groupId: json['group_id'].toString(),
         description: json['description'] ?? '',
         amount: (json['amount'] as num?)?.toDouble() ?? 0,
-        createdBy: json['createdBy']?.toString(),
-        createdAt: json['createdAt'] != null
-            ? DateTime.parse(json['createdAt'])
+        totalAmount: (json['total_amount'] as num?)?.toDouble() ?? 0,
+        expenseDate: json['expense_date'] != null
+            ? DateTime.parse(json['expense_date'])
             : null,
-        updatedAt: json['updatedAt'] != null
-            ? DateTime.parse(json['updatedAt'])
+        hasTicket: json['has_ticket'] ?? false,
+        ticketImageUrl: json['ticket_image_url']?.toString(),
+        participants: (json['participants'] as List?)
+                ?.map((e) => e.toString())
+                .toList() ??
+            [],
+        status: json['status']?.toString(),
+        createdBy: json['created_by']?.toString(),
+        createdAt: json['created_at'] != null
+            ? DateTime.parse(json['created_at'])
+            : null,
+        updatedAt: json['updated_at'] != null
+            ? DateTime.parse(json['updated_at'])
             : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'groupId': groupId,
+        'group_id': groupId,
         'description': description,
         'amount': amount,
-        'createdBy': createdBy,
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
+        'total_amount': totalAmount,
+        'expense_date': expenseDate?.toIso8601String(),
+        'has_ticket': hasTicket,
+        'ticket_image_url': ticketImageUrl,
+        'participants': participants,
+        'status': status,
+        'created_by': createdBy,
+        'created_at': createdAt?.toIso8601String(),
+        'updated_at': updatedAt?.toIso8601String(),
       };
 }

--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -7,22 +7,38 @@ class ExpenseRepository {
   ExpenseRepository(this._service);
 
   /// Retrieve all expenses for the specified group.
-  Future<List<Expense>> getExpenses(String groupId) async {
-    return _service.getExpenses(groupId);
+  Future<List<Expense>> getExpenses(
+    String groupId, {
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    return _service.getExpenses(
+      groupId,
+      startDate: startDate,
+      endDate: endDate,
+    );
   }
 
   /// Create a new expense in the given group.
   Future<Expense> createExpense(
     String groupId,
     String description,
-    double amount, {
+    double totalAmount, {
+    DateTime? expenseDate,
+    bool hasTicket = false,
+    String? ticketImageUrl,
     String? createdBy,
+    List<String> participants = const [],
   }) async {
     return _service.createExpense(
       groupId,
       description,
-      amount,
+      totalAmount,
+      expenseDate: expenseDate,
+      hasTicket: hasTicket,
+      ticketImageUrl: ticketImageUrl,
       createdBy: createdBy,
+      participants: participants,
     );
   }
 
@@ -31,13 +47,21 @@ class ExpenseRepository {
     String id,
     String groupId, {
     String? description,
-    double? amount,
+    double? totalAmount,
+    DateTime? expenseDate,
+    bool? hasTicket,
+    String? ticketImageUrl,
+    List<String>? participants,
   }) async {
     return _service.updateExpense(
       id,
       groupId,
       description: description,
-      amount: amount,
+      totalAmount: totalAmount,
+      expenseDate: expenseDate,
+      hasTicket: hasTicket,
+      ticketImageUrl: ticketImageUrl,
+      participants: participants,
     );
   }
 

--- a/lib/state/expenses/expense_provider.dart
+++ b/lib/state/expenses/expense_provider.dart
@@ -15,10 +15,15 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
 
   ExpenseNotifier(this._repo) : super(ExpenseState.initial());
 
-  Future<void> fetchExpenses(String groupId) async {
+  Future<void> fetchExpenses(String groupId,
+      {DateTime? startDate, DateTime? endDate}) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      final expenses = await _repo.getExpenses(groupId);
+      final expenses = await _repo.getExpenses(
+        groupId,
+        startDate: startDate,
+        endDate: endDate,
+      );
       state = state.copyWith(expenses: expenses, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(
@@ -33,16 +38,24 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
   Future<void> addExpense(
     String groupId,
     String description,
-    double amount, {
+    double totalAmount, {
+    DateTime? expenseDate,
+    bool hasTicket = false,
+    String? ticketImageUrl,
     String? createdBy,
+    List<String> participants = const [],
   }) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
       await _repo.createExpense(
         groupId,
         description,
-        amount,
+        totalAmount,
+        expenseDate: expenseDate,
+        hasTicket: hasTicket,
+        ticketImageUrl: ticketImageUrl,
         createdBy: createdBy,
+        participants: participants,
       );
       final expenses = await _repo.getExpenses(groupId);
       state = state.copyWith(expenses: expenses, isLoading: false);

--- a/lib/ui/screens/expenses/expense_form_screen.dart
+++ b/lib/ui/screens/expenses/expense_form_screen.dart
@@ -48,8 +48,14 @@ class ExpenseFormScreen extends HookConsumerWidget {
                           double.tryParse(amountController.text) ?? 0;
                       await ref
                           .read(expenseNotifierProvider.notifier)
-                          .addExpense(groupId, descController.text, amount,
-                              createdBy: createdByController.text);
+                          .addExpense(
+                            groupId,
+                            descController.text,
+                            amount,
+                            expenseDate: DateTime.now(),
+                            createdBy: createdByController.text,
+                            participants: const [],
+                          );
                       final error = ref.read(expenseNotifierProvider).error;
                       if (context.mounted && error == null) {
                         context.pop();


### PR DESCRIPTION
## Summary
- add total amount, ticket, date, participants and status to `Expense` model with snake_case serialization
- extend expense service/repository/provider to handle new fields and date filters
- update form screen to pass new parameters when creating expenses

## Testing
- `dart format lib/models/expense.dart lib/services/expense_service.dart lib/repositories/expense_repository.dart lib/state/expenses/expense_provider.dart lib/ui/screens/expenses/expense_form_screen.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a3e993c8324bd2868f83a45c8d4