### PR TITLE
feat(groups): manage members and balances

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,8 @@ import 'ui/screens/dashboard_screen.dart';
 import 'ui/screens/groups/group_list_screen.dart';
 import 'ui/screens/groups/group_detail_screen.dart';
 import 'ui/screens/groups/group_form_screen.dart';
+import 'ui/screens/groups/group_members_screen.dart';
+import 'ui/screens/groups/group_balances_screen.dart';
 import 'ui/screens/expenses/expense_list_screen.dart';
 import 'ui/screens/expenses/expense_detail_screen.dart';
 import 'ui/screens/expenses/expense_form_screen.dart';
@@ -38,6 +40,14 @@ class MyApp extends StatelessWidget {
             path: '/groups/:id',
             builder: (_, state) =>
                 GroupDetailScreen(id: state.pathParameters['id']!)),
+        GoRoute(
+            path: '/groups/:id/members',
+            builder: (_, state) =>
+                GroupMembersScreen(groupId: state.pathParameters['id']!)),
+        GoRoute(
+            path: '/groups/:id/balances',
+            builder: (_, state) =>
+                GroupBalancesScreen(groupId: state.pathParameters['id']!)),
         GoRoute(
             path: '/groups/:id/expenses',
             builder: (_, state) =>

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -25,4 +25,21 @@ class GroupRepository {
   Future<void> deleteGroup(String id) async {
     await _service.deleteGroup(id);
   }
+
+  Future<void> addMember(String groupId, String userId, {String? role}) async {
+    await _service.addMember(groupId, userId, role: role);
+  }
+
+  Future<void> updateMemberRole(
+      String groupId, String memberId, String role) async {
+    await _service.updateMemberRole(groupId, memberId, role);
+  }
+
+  Future<void> deleteMember(String groupId, String memberId) async {
+    await _service.deleteMember(groupId, memberId);
+  }
+
+  Future<List<dynamic>> getBalances(String groupId) async {
+    return _service.getBalances(groupId);
+  }
 }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -26,18 +26,25 @@ class GroupService {
     }
   }
 
-  Future<Group> createGroup(String name) async {
+  Future<Group> createGroup(String name, {String? description}) async {
     try {
-      final res = await _client.post("/groups", data: {"name": name});
+      final res = await _client.post("/groups", data: {
+        "name": name,
+        if (description != null) "description": description,
+      });
       return Group.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }
   }
 
-  Future<Group> updateGroup(String id, {required String name}) async {
+  Future<Group> updateGroup(String id,
+      {required String name, String? description}) async {
     try {
-      final res = await _client.put("/groups/$id", data: {"name": name});
+      final res = await _client.put("/groups/$id", data: {
+        "name": name,
+        if (description != null) "description": description,
+      });
       return Group.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
@@ -47,6 +54,46 @@ class GroupService {
   Future<void> deleteGroup(String id) async {
     try {
       await _client.delete("/groups/$id");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> addMember(String groupId, String userId, {String? role}) async {
+    try {
+      await _client.post("/groups/$groupId/members", data: {
+        "userId": userId,
+        if (role != null) "role": role,
+      });
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> updateMemberRole(
+      String groupId, String memberId, String role) async {
+    try {
+      await _client.put("/groups/$groupId/members/$memberId", data: {
+        "role": role,
+      });
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<void> deleteMember(String groupId, String memberId) async {
+    try {
+      await _client.delete("/groups/$groupId/members/$memberId");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<List<dynamic>> getBalances(String groupId) async {
+    try {
+      final res = await _client.get("/groups/$groupId/balances");
+      final data = res.data as List;
+      return data;
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -27,10 +27,10 @@ class GroupNotifier extends StateNotifier<GroupState> {
     }
   }
 
-  Future<void> addGroup(String name) async {
+  Future<void> addGroup(String name, {String? description}) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
-      await _repo.createGroup(name);
+      await _repo.createGroup(name, description: description);
       final groups = await _repo.getGroups();
       state = state.copyWith(groups: groups, isLoading: false);
     } on DioException catch (e) {
@@ -38,6 +38,79 @@ class GroupNotifier extends StateNotifier<GroupState> {
           isLoading: false, error: e.response?.data['message'] ?? e.message);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> updateGroup(String id, String name, {String? description}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repo.updateGroup(id, name: name, description: description);
+      final groups = await _repo.getGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> addMember(String groupId, String userId, {String? role}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repo.addMember(groupId, userId, role: role);
+      final groups = await _repo.getGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> updateMemberRole(
+      String groupId, String memberId, String role) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repo.updateMemberRole(groupId, memberId, role);
+      final groups = await _repo.getGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> deleteMember(String groupId, String memberId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      await _repo.deleteMember(groupId, memberId);
+      final groups = await _repo.getGroups();
+      state = state.copyWith(groups: groups, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<List<dynamic>> getBalances(String groupId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final balances = await _repo.getBalances(groupId);
+      state = state.copyWith(isLoading: false);
+      return balances;
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+      return [];
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return [];
     }
   }
 

--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -7,4 +7,6 @@ class AppRoutes {
   static const expenses = '/groups/:id/expenses';
   static const expenseForm = '/groups/:id/expenses/new';
   static const expenseDetail = '/groups/:id/expenses/:expId';
+  static const groupMembers = '/groups/:id/members';
+  static const groupBalances = '/groups/:id/balances';
 }

--- a/lib/ui/screens/groups/group_balances_screen.dart
+++ b/lib/ui/screens/groups/group_balances_screen.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../../state/groups/group_provider.dart';
+
+class GroupBalancesScreen extends HookConsumerWidget {
+  final String groupId;
+  const GroupBalancesScreen({super.key, required this.groupId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(groupNotifierProvider);
+    final balances = useState<List<dynamic>>([]);
+
+    useEffect(() {
+      Future(() async {
+        final res =
+            await ref.read(groupNotifierProvider.notifier).getBalances(groupId);
+        balances.value = res;
+      });
+      return null;
+    }, [groupId]);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Balances')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: balances.value.length,
+                  itemBuilder: (_, index) {
+                    final balance = balances.value[index];
+                    return ListTile(
+                      title: Text(balance.toString()),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/ui/screens/groups/group_detail_screen.dart
+++ b/lib/ui/screens/groups/group_detail_screen.dart
@@ -39,11 +39,25 @@ class GroupDetailScreen extends HookConsumerWidget {
                             children: [
                           Text('ID: ${group.id}'),
                           Text('Nombre: ${group.name}'),
+                          if (group.description != null)
+                            Text('Descripción: ${group.description}'),
                           const SizedBox(height: 20),
                           ElevatedButton(
                             onPressed: () =>
                                 context.push('/groups/${group.id}/expenses'),
                             child: const Text('Ver gastos'),
+                          ),
+                          const SizedBox(height: 10),
+                          ElevatedButton(
+                            onPressed: () =>
+                                context.push('/groups/${group.id}/members'),
+                            child: const Text('Gestionar miembros'),
+                          ),
+                          const SizedBox(height: 10),
+                          ElevatedButton(
+                            onPressed: () =>
+                                context.push('/groups/${group.id}/balances'),
+                            child: const Text('Ver balances'),
                           ),
                         ],
                       ),

--- a/lib/ui/screens/groups/group_form_screen.dart
+++ b/lib/ui/screens/groups/group_form_screen.dart
@@ -10,6 +10,7 @@ class GroupFormScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final nameController = useTextEditingController();
+    final descriptionController = useTextEditingController();
     final state = ref.watch(groupNotifierProvider);
 
     return Scaffold(
@@ -23,6 +24,11 @@ class GroupFormScreen extends HookConsumerWidget {
               decoration: const InputDecoration(labelText: 'Nombre'),
             ),
             const SizedBox(height: 20),
+            TextField(
+              controller: descriptionController,
+              decoration: const InputDecoration(labelText: 'Descripción'),
+            ),
+            const SizedBox(height: 20),
             if (state.error != null) ...[
               Text(state.error!, style: const TextStyle(color: Colors.red)),
               const SizedBox(height: 20),
@@ -33,7 +39,8 @@ class GroupFormScreen extends HookConsumerWidget {
                   : () async {
                       await ref
                           .read(groupNotifierProvider.notifier)
-                          .addGroup(nameController.text);
+                          .addGroup(nameController.text,
+                              description: descriptionController.text);
                       final error = ref.read(groupNotifierProvider).error;
                       if (context.mounted && error == null) {
                         context.pop();

--- a/lib/ui/screens/groups/group_members_screen.dart
+++ b/lib/ui/screens/groups/group_members_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../../../state/groups/group_provider.dart';
+
+class GroupMembersScreen extends HookConsumerWidget {
+  final String groupId;
+  const GroupMembersScreen({super.key, required this.groupId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(groupNotifierProvider);
+    final userIdController = useTextEditingController();
+    final roleController = useTextEditingController();
+    final memberIdController = useTextEditingController();
+    final updateRoleController = useTextEditingController();
+    final deleteMemberController = useTextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Miembros')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            if (state.error != null) ...[
+              Text(state.error!, style: const TextStyle(color: Colors.red)),
+              const SizedBox(height: 20),
+            ],
+            const Text('Agregar miembro'),
+            TextField(
+              controller: userIdController,
+              decoration: const InputDecoration(labelText: 'Usuario ID'),
+            ),
+            TextField(
+              controller: roleController,
+              decoration: const InputDecoration(labelText: 'Rol'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: state.isLoading
+                  ? null
+                  : () async {
+                      await ref
+                          .read(groupNotifierProvider.notifier)
+                          .addMember(groupId, userIdController.text,
+                              role: roleController.text.isEmpty
+                                  ? null
+                                  : roleController.text);
+                    },
+              child: state.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Agregar'),
+            ),
+            const Divider(height: 40),
+            const Text('Actualizar rol'),
+            TextField(
+              controller: memberIdController,
+              decoration: const InputDecoration(labelText: 'Miembro ID'),
+            ),
+            TextField(
+              controller: updateRoleController,
+              decoration: const InputDecoration(labelText: 'Nuevo rol'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: state.isLoading
+                  ? null
+                  : () async {
+                      await ref
+                          .read(groupNotifierProvider.notifier)
+                          .updateMemberRole(groupId, memberIdController.text,
+                              updateRoleController.text);
+                    },
+              child: state.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Actualizar'),
+            ),
+            const Divider(height: 40),
+            const Text('Eliminar miembro'),
+            TextField(
+              controller: deleteMemberController,
+              decoration: const InputDecoration(labelText: 'Miembro ID'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: state.isLoading
+                  ? null
+                  : () async {
+                      await ref
+                          .read(groupNotifierProvider.notifier)
+                          .deleteMember(groupId, deleteMemberController.text);
+                    },
+              child: state.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Eliminar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- support description in group creation and updates
- allow member management and balance retrieval
- add screens for member management and balance viewing

## Testing
- `dart format lib/services/group_service.dart lib/repositories/group_repository.dart lib/state/groups/group_provider.dart lib/ui/screens/groups/group_form_screen.dart lib/ui/screens/groups/group_detail_screen.dart lib/ui/screens/groups/group_members_screen.dart lib/ui/screens/groups/group_balances_screen.dart lib/ui/routes.dart lib/main.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a3fc048832482fc42190c64cbba