### PR TITLE
Add registration and profile screens and routing

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'config/locator.dart';
 import 'ui/routes.dart';
 import 'ui/screens/login_screen.dart';
 import 'ui/screens/dashboard_screen.dart';
+import 'ui/screens/register_screen.dart';
+import 'ui/screens/profile_screen.dart';
 import 'ui/screens/groups/group_list_screen.dart';
 import 'ui/screens/groups/group_detail_screen.dart';
 import 'ui/screens/groups/group_form_screen.dart';
@@ -28,8 +30,12 @@ class MyApp extends StatelessWidget {
       routes: [
         GoRoute(path: AppRoutes.login, builder: (_, __) => const LoginScreen()),
         GoRoute(
+            path: AppRoutes.register, builder: (_, __) => const RegisterScreen()),
+        GoRoute(
             path: AppRoutes.dashboard,
             builder: (_, __) => const DashboardScreen()),
+        GoRoute(
+            path: AppRoutes.profile, builder: (_, __) => const ProfileScreen()),
         GoRoute(path: AppRoutes.groups,
             builder: (_, __) => const GroupListScreen()),
         GoRoute(path: AppRoutes.groupForm,

--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -1,6 +1,8 @@
 class AppRoutes {
   static const login = '/login';
+  static const register = '/register';
   static const dashboard = '/dashboard';
+  static const profile = '/profile';
   static const groups = '/groups';
   static const groupForm = '/groups/new';
   static const groupDetail = '/groups/:id';

--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import '../routes.dart';
 
 class DashboardScreen extends StatelessWidget {
   const DashboardScreen({super.key});
@@ -7,10 +8,18 @@ class DashboardScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Dashboard')),
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: [
+          IconButton(
+            onPressed: () => context.push(AppRoutes.profile),
+            icon: const Icon(Icons.person),
+          )
+        ],
+      ),
       body: Center(
         child: ElevatedButton(
-          onPressed: () => context.push('/groups'),
+          onPressed: () => context.push(AppRoutes.groups),
           child: const Text('Ver grupos'),
         ),
       ),

--- a/lib/ui/screens/profile_screen.dart
+++ b/lib/ui/screens/profile_screen.dart
@@ -1,0 +1,139 @@
+import "package:flutter/material.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+
+import "../../state/auth/auth_provider.dart";
+
+class ProfileScreen extends ConsumerStatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  ConsumerState<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends ConsumerState<ProfileScreen> {
+  final _profileFormKey = GlobalKey<FormState>();
+  final _passwordFormKey = GlobalKey<FormState>();
+
+  final _name = TextEditingController();
+  final _email = TextEditingController();
+  final _currentPassword = TextEditingController();
+  final _newPassword = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(authNotifierProvider);
+
+    ref.listen(authNotifierProvider, (prev, next) {
+      if (next is AuthProfileUpdated) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text("Perfil actualizado")));
+      } else if (next is AuthPasswordUpdated) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text("Contraseña actualizada")));
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Perfil")),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: Column(
+              children: [
+                Form(
+                  key: _profileFormKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TextFormField(
+                        controller: _name,
+                        decoration: const InputDecoration(labelText: "Nombre"),
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _email,
+                        decoration: const InputDecoration(labelText: "Email"),
+                      ),
+                      const SizedBox(height: 20),
+                      ElevatedButton(
+                        onPressed: state is! AuthLoading
+                            ? () {
+                                if (_profileFormKey.currentState!.validate()) {
+                                  ref
+                                      .read(authNotifierProvider.notifier)
+                                      .updateProfile(
+                                        name: _name.text.trim().isEmpty
+                                            ? null
+                                            : _name.text.trim(),
+                                        email: _email.text.trim().isEmpty
+                                            ? null
+                                            : _email.text.trim(),
+                                      );
+                                }
+                              }
+                            : null,
+                        child: Text(state is AuthLoading
+                            ? "Actualizando..."
+                            : "Actualizar perfil"),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 40),
+                Form(
+                  key: _passwordFormKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      TextFormField(
+                        controller: _currentPassword,
+                        decoration:
+                            const InputDecoration(labelText: "Contraseña actual"),
+                        obscureText: true,
+                        validator: (v) =>
+                            (v == null || v.isEmpty) ? "Requerido" : null,
+                      ),
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _newPassword,
+                        decoration:
+                            const InputDecoration(labelText: "Nueva contraseña"),
+                        obscureText: true,
+                        validator: (v) =>
+                            (v == null || v.isEmpty) ? "Requerido" : null,
+                      ),
+                      const SizedBox(height: 20),
+                      ElevatedButton(
+                        onPressed: state is! AuthLoading
+                            ? () {
+                                if (_passwordFormKey.currentState!.validate()) {
+                                  ref
+                                      .read(authNotifierProvider.notifier)
+                                      .updatePassword(
+                                        _currentPassword.text.trim(),
+                                        _newPassword.text.trim(),
+                                      );
+                                }
+                              }
+                            : null,
+                        child: Text(state is AuthLoading
+                            ? "Actualizando..."
+                            : "Actualizar contraseña"),
+                      ),
+                    ],
+                  ),
+                ),
+                if (state is AuthError) ...[
+                  const SizedBox(height: 12),
+                  Text(state.message, style: const TextStyle(color: Colors.red)),
+                ]
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/register_screen.dart
+++ b/lib/ui/screens/register_screen.dart
@@ -1,18 +1,20 @@
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
-import "../../state/auth/auth_provider.dart";
 import "package:go_router/go_router.dart";
+
+import "../../state/auth/auth_provider.dart";
 import "../routes.dart";
 
-class LoginScreen extends ConsumerStatefulWidget {
-  const LoginScreen({super.key});
+class RegisterScreen extends ConsumerStatefulWidget {
+  const RegisterScreen({super.key});
 
   @override
-  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+  ConsumerState<RegisterScreen> createState() => _RegisterScreenState();
 }
 
-class _LoginScreenState extends ConsumerState<LoginScreen> {
+class _RegisterScreenState extends ConsumerState<RegisterScreen> {
   final _formKey = GlobalKey<FormState>();
+  final _name = TextEditingController();
   final _email = TextEditingController();
   final _password = TextEditingController();
 
@@ -21,13 +23,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
     final state = ref.watch(authNotifierProvider);
 
     ref.listen(authNotifierProvider, (prev, next) {
-      if (next is AuthAuthenticated) {
-        context.go(AppRoutes.dashboard);
+      if (next is AuthRegistered) {
+        context.go(AppRoutes.login);
       }
     });
 
     return Scaffold(
-      appBar: AppBar(title: const Text("Login")),
+      appBar: AppBar(title: const Text("Registro")),
       body: Center(
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 420),
@@ -36,6 +38,11 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
             child: Form(
               key: _formKey,
               child: Column(mainAxisSize: MainAxisSize.min, children: [
+                TextFormField(
+                  controller: _name,
+                  decoration: const InputDecoration(labelText: "Nombre"),
+                ),
+                const SizedBox(height: 12),
                 TextFormField(
                   controller: _email,
                   decoration: const InputDecoration(labelText: "Email"),
@@ -53,18 +60,23 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                   onPressed: state is! AuthLoading
                       ? () {
                           if (_formKey.currentState!.validate()) {
-                            ref.read(authNotifierProvider.notifier).login(
+                            ref.read(authNotifierProvider.notifier).register(
                                   _email.text.trim(),
                                   _password.text.trim(),
+                                  name: _name.text.trim().isEmpty
+                                      ? null
+                                      : _name.text.trim(),
                                 );
                           }
                         }
                       : null,
-                  child: Text(state is AuthLoading ? "Entrando..." : "Entrar"),
+                  child:
+                      Text(state is AuthLoading ? "Registrando..." : "Registrar"),
                 ),
+                const SizedBox(height: 12),
                 TextButton(
-                  onPressed: () => context.go(AppRoutes.register),
-                  child: const Text("Crear cuenta"),
+                  onPressed: () => context.go(AppRoutes.login),
+                  child: const Text("¿Ya tienes cuenta? Inicia sesión"),
                 ),
                 if (state is AuthError) ...[
                   const SizedBox(height: 12),


### PR DESCRIPTION
## Summary
- add registration screen with form to create new account
- add profile screen to update user info and password
- wire up routes and navigation for /register and /profile

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a41d4a08324befccd2d3d6e8418