### PR TITLE
Add notifications, recurring payments, and reports modules

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -7,6 +7,8 @@ import "../repositories/group_repository.dart";
 import "../repositories/invitation_repository.dart";
 import "../repositories/notification_repository.dart";
 import "../repositories/payment_repository.dart";
+import "../repositories/recurring_payment_repository.dart";
+import "../repositories/reports_repository.dart";
 import "../services/api_client.dart";
 import "../services/auth_service.dart";
 import "../services/expense_service.dart";
@@ -14,6 +16,8 @@ import "../services/group_service.dart";
 import "../services/invitation_service.dart";
 import "../services/notification_service.dart";
 import "../services/payment_service.dart";
+import "../services/recurring_payment_service.dart";
+import "../services/reports_service.dart";
 
 final GetIt locator = GetIt.instance;
 
@@ -29,6 +33,9 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<InvitationService>(() => InvitationService(locator<ApiClient>()));
   locator.registerLazySingleton<PaymentService>(() => PaymentService(locator<ApiClient>()));
   locator.registerLazySingleton<NotificationService>(() => NotificationService(locator<ApiClient>()));
+  locator.registerLazySingleton<RecurringPaymentService>(() =>
+      RecurringPaymentService(locator<ApiClient>()));
+  locator.registerLazySingleton<ReportsService>(() => ReportsService(locator<ApiClient>()));
 
   // Repositories
   locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
@@ -39,5 +46,9 @@ Future<void> setupLocator() async {
   locator.registerLazySingleton<InvitationRepository>(() => InvitationRepository(locator<InvitationService>()));
   locator.registerLazySingleton<PaymentRepository>(() => PaymentRepository(locator<PaymentService>()));
   locator.registerLazySingleton<NotificationRepository>(() => NotificationRepository(locator<NotificationService>()));
+  locator.registerLazySingleton<RecurringPaymentRepository>(
+      () => RecurringPaymentRepository(locator<RecurringPaymentService>()));
+  locator.registerLazySingleton<ReportsRepository>(
+      () => ReportsRepository(locator<ReportsService>()));
 }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,9 @@ import 'ui/screens/groups/group_form_screen.dart';
 import 'ui/screens/expenses/expense_list_screen.dart';
 import 'ui/screens/expenses/expense_detail_screen.dart';
 import 'ui/screens/expenses/expense_form_screen.dart';
+import 'ui/screens/notifications_screen.dart';
+import 'ui/screens/recurring_payments/recurring_payments_screen.dart';
+import 'ui/screens/reports/reports_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -34,6 +37,15 @@ class MyApp extends StatelessWidget {
             builder: (_, __) => const GroupListScreen()),
         GoRoute(path: AppRoutes.groupForm,
             builder: (_, __) => const GroupFormScreen()),
+        GoRoute(
+            path: AppRoutes.notifications,
+            builder: (_, __) => const NotificationsScreen()),
+        GoRoute(
+            path: AppRoutes.recurringPayments,
+            builder: (_, __) => const RecurringPaymentsScreen()),
+        GoRoute(
+            path: AppRoutes.reports,
+            builder: (_, __) => const ReportsScreen()),
         GoRoute(
             path: '/groups/:id',
             builder: (_, state) =>

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -1,0 +1,33 @@
+class AppNotification {
+  final String id;
+  final String title;
+  final String body;
+  final bool isRead;
+  final DateTime? createdAt;
+
+  AppNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.isRead,
+    this.createdAt,
+  });
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) => AppNotification(
+        id: json['id'].toString(),
+        title: json['title'] ?? '',
+        body: json['body'] ?? '',
+        isRead: json['isRead'] ?? json['read'] ?? false,
+        createdAt: json['createdAt'] != null
+            ? DateTime.parse(json['createdAt'])
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'body': body,
+        'isRead': isRead,
+        'createdAt': createdAt?.toIso8601String(),
+      };
+}

--- a/lib/models/recurring_payment.dart
+++ b/lib/models/recurring_payment.dart
@@ -1,0 +1,37 @@
+class RecurringPayment {
+  final String id;
+  final String groupId;
+  final String description;
+  final double amount;
+  final String frequency;
+  final DateTime? nextDate;
+
+  RecurringPayment({
+    required this.id,
+    required this.groupId,
+    required this.description,
+    required this.amount,
+    required this.frequency,
+    this.nextDate,
+  });
+
+  factory RecurringPayment.fromJson(Map<String, dynamic> json) => RecurringPayment(
+        id: json['id'].toString(),
+        groupId: json['groupId'].toString(),
+        description: json['description'] ?? '',
+        amount: (json['amount'] as num?)?.toDouble() ?? 0,
+        frequency: json['frequency'] ?? '',
+        nextDate: json['nextDate'] != null
+            ? DateTime.parse(json['nextDate'])
+            : null,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'groupId': groupId,
+        'description': description,
+        'amount': amount,
+        'frequency': frequency,
+        'nextDate': nextDate?.toIso8601String(),
+      };
+}

--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -1,0 +1,23 @@
+class Report {
+  final String id;
+  final String title;
+  final String description;
+
+  Report({
+    required this.id,
+    required this.title,
+    required this.description,
+  });
+
+  factory Report.fromJson(Map<String, dynamic> json) => Report(
+        id: json['id'].toString(),
+        title: json['title'] ?? '',
+        description: json['description'] ?? '',
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'description': description,
+      };
+}

--- a/lib/repositories/notification_repository.dart
+++ b/lib/repositories/notification_repository.dart
@@ -1,3 +1,4 @@
+import '../models/notification.dart';
 import "../services/notification_service.dart";
 
 class NotificationRepository {
@@ -7,7 +8,8 @@ class NotificationRepository {
   Future<void> registerDevice(String deviceToken, String deviceType) =>
       _service.registerDevice(deviceToken, deviceType);
 
-  Future<List<dynamic>> fetchNotifications() => _service.getNotifications();
+  Future<List<AppNotification>> fetchNotifications() =>
+      _service.getNotifications();
 
   Future<void> markAsRead(String id) => _service.markAsRead(id);
 

--- a/lib/repositories/recurring_payment_repository.dart
+++ b/lib/repositories/recurring_payment_repository.dart
@@ -1,0 +1,39 @@
+import '../models/recurring_payment.dart';
+import '../services/recurring_payment_service.dart';
+
+class RecurringPaymentRepository {
+  final RecurringPaymentService _service;
+  RecurringPaymentRepository(this._service);
+
+  Future<List<RecurringPayment>> getRecurringPayments({String? groupId}) =>
+      _service.getRecurringPayments(groupId: groupId);
+
+  Future<RecurringPayment> createRecurringPayment({
+    required String groupId,
+    required String description,
+    required double amount,
+    required String frequency,
+  }) =>
+      _service.createRecurringPayment(
+        groupId: groupId,
+        description: description,
+        amount: amount,
+        frequency: frequency,
+      );
+
+  Future<RecurringPayment> updateRecurringPayment(String id,
+          {String? description,
+          double? amount,
+          String? frequency,
+          DateTime? nextDate}) =>
+      _service.updateRecurringPayment(
+        id,
+        description: description,
+        amount: amount,
+        frequency: frequency,
+        nextDate: nextDate,
+      );
+
+  Future<void> deleteRecurringPayment(String id) =>
+      _service.deleteRecurringPayment(id);
+}

--- a/lib/repositories/reports_repository.dart
+++ b/lib/repositories/reports_repository.dart
@@ -1,0 +1,9 @@
+import '../models/report.dart';
+import '../services/reports_service.dart';
+
+class ReportsRepository {
+  final ReportsService _service;
+  ReportsRepository(this._service);
+
+  Future<List<Report>> fetchReports() => _service.getReports();
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,5 +1,6 @@
 import "package:dio/dio.dart";
 
+import "../models/notification.dart";
 import "../services/api_client.dart";
 
 class NotificationService {
@@ -17,10 +18,11 @@ class NotificationService {
     }
   }
 
-  Future<List<dynamic>> getNotifications() async {
+  Future<List<AppNotification>> getNotifications() async {
     try {
       final res = await _client.get("/notifications");
-      return List<dynamic>.from(res.data);
+      final data = res.data as List;
+      return data.map((e) => AppNotification.fromJson(e)).toList();
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }

--- a/lib/services/recurring_payment_service.dart
+++ b/lib/services/recurring_payment_service.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+
+import '../models/recurring_payment.dart';
+import '../services/api_client.dart';
+
+class RecurringPaymentService {
+  final ApiClient _client;
+  RecurringPaymentService(this._client);
+
+  Future<List<RecurringPayment>> getRecurringPayments({String? groupId}) async {
+    try {
+      final res = await _client.get('/recurring-payments', queryParameters: {
+        if (groupId != null) 'groupId': groupId,
+      });
+      final data = res.data as List;
+      return data.map((e) => RecurringPayment.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? e.message);
+    }
+  }
+
+  Future<RecurringPayment> createRecurringPayment({
+    required String groupId,
+    required String description,
+    required double amount,
+    required String frequency,
+  }) async {
+    try {
+      final res = await _client.post('/recurring-payments', data: {
+        'groupId': groupId,
+        'description': description,
+        'amount': amount,
+        'frequency': frequency,
+      });
+      return RecurringPayment.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? e.message);
+    }
+  }
+
+  Future<RecurringPayment> updateRecurringPayment(String id,
+      {String? description,
+      double? amount,
+      String? frequency,
+      DateTime? nextDate}) async {
+    try {
+      final res = await _client.put('/recurring-payments/$id', data: {
+        if (description != null) 'description': description,
+        if (amount != null) 'amount': amount,
+        if (frequency != null) 'frequency': frequency,
+        if (nextDate != null) 'nextDate': nextDate.toIso8601String(),
+      });
+      return RecurringPayment.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? e.message);
+    }
+  }
+
+  Future<void> deleteRecurringPayment(String id) async {
+    try {
+      await _client.delete('/recurring-payments/$id');
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? e.message);
+    }
+  }
+}

--- a/lib/services/reports_service.dart
+++ b/lib/services/reports_service.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+
+import '../models/report.dart';
+import '../services/api_client.dart';
+
+class ReportsService {
+  final ApiClient _client;
+  ReportsService(this._client);
+
+  Future<List<Report>> getReports() async {
+    try {
+      final res = await _client.get('/reports');
+      final data = res.data as List;
+      return data.map((e) => Report.fromJson(e)).toList();
+    } on DioException catch (e) {
+      throw Exception(e.response?.data['message'] ?? e.message);
+    }
+  }
+}

--- a/lib/state/notifications/notification_provider.dart
+++ b/lib/state/notifications/notification_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+
+import '../../config/locator.dart';
+import '../../repositories/notification_repository.dart';
+import 'notification_state.dart';
+
+final notificationNotifierProvider =
+    StateNotifierProvider<NotificationNotifier, NotificationState>((ref) {
+  return NotificationNotifier(locator<NotificationRepository>());
+});
+
+class NotificationNotifier extends StateNotifier<NotificationState> {
+  final NotificationRepository _repo;
+  NotificationNotifier(this._repo) : super(NotificationState.initial());
+
+  Future<void> fetchNotifications() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final notifications = await _repo.fetchNotifications();
+      state = state.copyWith(
+          notifications: notifications, isLoading: false, error: null);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.response?.data['message'] ?? e.message,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> markAsRead(String id) async {
+    try {
+      await _repo.markAsRead(id);
+      await fetchNotifications();
+    } catch (_) {}
+  }
+
+  Future<void> delete(String id) async {
+    try {
+      await _repo.deleteNotification(id);
+      state = state.copyWith(
+        notifications: state.notifications.where((n) => n.id != id).toList(),
+      );
+    } catch (_) {}
+  }
+}

--- a/lib/state/notifications/notification_state.dart
+++ b/lib/state/notifications/notification_state.dart
@@ -1,0 +1,27 @@
+import '../../models/notification.dart';
+
+class NotificationState {
+  final List<AppNotification> notifications;
+  final bool isLoading;
+  final String? error;
+
+  const NotificationState({
+    this.notifications = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  NotificationState copyWith({
+    List<AppNotification>? notifications,
+    bool? isLoading,
+    String? error,
+  }) {
+    return NotificationState(
+      notifications: notifications ?? this.notifications,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+
+  factory NotificationState.initial() => const NotificationState();
+}

--- a/lib/state/recurring_payments/recurring_payment_provider.dart
+++ b/lib/state/recurring_payments/recurring_payment_provider.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+
+import '../../config/locator.dart';
+import '../../repositories/recurring_payment_repository.dart';
+import 'recurring_payment_state.dart';
+
+final recurringPaymentNotifierProvider =
+    StateNotifierProvider<RecurringPaymentNotifier, RecurringPaymentState>((ref) {
+  return RecurringPaymentNotifier(locator<RecurringPaymentRepository>());
+});
+
+class RecurringPaymentNotifier
+    extends StateNotifier<RecurringPaymentState> {
+  final RecurringPaymentRepository _repo;
+  RecurringPaymentNotifier(this._repo)
+      : super(RecurringPaymentState.initial());
+
+  Future<void> fetchPayments({String? groupId}) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final payments = await _repo.getRecurringPayments(groupId: groupId);
+      state = state.copyWith(payments: payments, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.response?.data['message'] ?? e.message,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+}

--- a/lib/state/recurring_payments/recurring_payment_state.dart
+++ b/lib/state/recurring_payments/recurring_payment_state.dart
@@ -1,0 +1,27 @@
+import '../../models/recurring_payment.dart';
+
+class RecurringPaymentState {
+  final List<RecurringPayment> payments;
+  final bool isLoading;
+  final String? error;
+
+  const RecurringPaymentState({
+    this.payments = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  RecurringPaymentState copyWith({
+    List<RecurringPayment>? payments,
+    bool? isLoading,
+    String? error,
+  }) {
+    return RecurringPaymentState(
+      payments: payments ?? this.payments,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+
+  factory RecurringPaymentState.initial() => const RecurringPaymentState();
+}

--- a/lib/state/reports/report_provider.dart
+++ b/lib/state/reports/report_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
+
+import '../../config/locator.dart';
+import '../../repositories/reports_repository.dart';
+import 'report_state.dart';
+
+final reportNotifierProvider =
+    StateNotifierProvider<ReportNotifier, ReportState>((ref) {
+  return ReportNotifier(locator<ReportsRepository>());
+});
+
+class ReportNotifier extends StateNotifier<ReportState> {
+  final ReportsRepository _repo;
+  ReportNotifier(this._repo) : super(ReportState.initial());
+
+  Future<void> fetchReports() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final reports = await _repo.fetchReports();
+      state = state.copyWith(reports: reports, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.response?.data['message'] ?? e.message,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+}

--- a/lib/state/reports/report_state.dart
+++ b/lib/state/reports/report_state.dart
@@ -1,0 +1,27 @@
+import '../../models/report.dart';
+
+class ReportState {
+  final List<Report> reports;
+  final bool isLoading;
+  final String? error;
+
+  const ReportState({
+    this.reports = const [],
+    this.isLoading = false,
+    this.error,
+  });
+
+  ReportState copyWith({
+    List<Report>? reports,
+    bool? isLoading,
+    String? error,
+  }) {
+    return ReportState(
+      reports: reports ?? this.reports,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+
+  factory ReportState.initial() => const ReportState();
+}

--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -7,4 +7,7 @@ class AppRoutes {
   static const expenses = '/groups/:id/expenses';
   static const expenseForm = '/groups/:id/expenses/new';
   static const expenseDetail = '/groups/:id/expenses/:expId';
+  static const notifications = '/notifications';
+  static const recurringPayments = '/recurring-payments';
+  static const reports = '/reports';
 }

--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -9,9 +9,29 @@ class DashboardScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Dashboard')),
       body: Center(
-        child: ElevatedButton(
-          onPressed: () => context.push('/groups'),
-          child: const Text('Ver grupos'),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ElevatedButton(
+              onPressed: () => context.push('/groups'),
+              child: const Text('Ver grupos'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () => context.push('/notifications'),
+              child: const Text('Notificaciones'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () => context.push('/recurring-payments'),
+              child: const Text('Pagos recurrentes'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () => context.push('/reports'),
+              child: const Text('Reportes'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/ui/screens/notifications_screen.dart
+++ b/lib/ui/screens/notifications_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../state/notifications/notification_provider.dart';
+
+class NotificationsScreen extends HookConsumerWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(notificationNotifierProvider);
+
+    useEffect(() {
+      ref.read(notificationNotifierProvider.notifier).fetchNotifications();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notificaciones')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: state.notifications.length,
+                  itemBuilder: (_, index) {
+                    final n = state.notifications[index];
+                    return ListTile(
+                      title: Text(n.title),
+                      subtitle: Text(n.body),
+                      trailing:
+                          n.isRead ? null : const Icon(Icons.mark_email_unread),
+                      onTap: () => ref
+                          .read(notificationNotifierProvider.notifier)
+                          .markAsRead(n.id),
+                      onLongPress: () => ref
+                          .read(notificationNotifierProvider.notifier)
+                          .delete(n.id),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/ui/screens/recurring_payments/recurring_payments_screen.dart
+++ b/lib/ui/screens/recurring_payments/recurring_payments_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../state/recurring_payments/recurring_payment_provider.dart';
+
+class RecurringPaymentsScreen extends HookConsumerWidget {
+  const RecurringPaymentsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(recurringPaymentNotifierProvider);
+
+    useEffect(() {
+      ref
+          .read(recurringPaymentNotifierProvider.notifier)
+          .fetchPayments();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pagos recurrentes')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: state.payments.length,
+                  itemBuilder: (_, index) {
+                    final p = state.payments[index];
+                    return ListTile(
+                      title: Text(p.description),
+                      subtitle:
+                          Text('${p.amount.toStringAsFixed(2)} - ${p.frequency}'),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/ui/screens/reports/reports_screen.dart
+++ b/lib/ui/screens/reports/reports_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../../state/reports/report_provider.dart';
+
+class ReportsScreen extends HookConsumerWidget {
+  const ReportsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(reportNotifierProvider);
+
+    useEffect(() {
+      ref.read(reportNotifierProvider.notifier).fetchReports();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reportes')),
+      body: state.isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null
+              ? Center(child: Text(state.error!))
+              : ListView.builder(
+                  itemCount: state.reports.length,
+                  itemBuilder: (_, index) {
+                    final r = state.reports[index];
+                    return ListTile(
+                      title: Text(r.title),
+                      subtitle: Text(r.description),
+                    );
+                  },
+                ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Map notification data to models and expose them through a new notifications screen
- Introduce recurring payment and report modules with services, repositories, providers, and UI
- Wire dashboard navigation and routes for notifications, recurring payments, and reports

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a432898832486b1ee7b709f66f7