### PR TITLE
feat: handle registration tokens in register screen

### DIFF
--- a/lib/state/app_mode_provider.dart
+++ b/lib/state/app_mode_provider.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the current application mode, either `public` or `private`.
+/// Defaults to `public`.
+final appModeProvider = Provider<String>((ref) => 'public');
+

--- a/lib/ui/screens/register_screen.dart
+++ b/lib/ui/screens/register_screen.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:go_router/go_router.dart";
 
 import "../../state/auth/auth_provider.dart";
+import "../../state/app_mode_provider.dart";
 import "../routes.dart";
 
 class RegisterScreen extends ConsumerStatefulWidget {
@@ -17,10 +18,14 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
   final _name = TextEditingController();
   final _email = TextEditingController();
   final _password = TextEditingController();
+  final _registrationToken = TextEditingController();
+  final _invitationToken = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(authNotifierProvider);
+    final appMode = ref.watch(appModeProvider);
+    final isPrivate = appMode == 'private';
 
     ref.listen(authNotifierProvider, (prev, next) {
       if (next is AuthRegistered) {
@@ -55,6 +60,22 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                   obscureText: true,
                   validator: (v) => (v == null || v.isEmpty) ? "Requerido" : null,
                 ),
+                if (isPrivate) ...[
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _registrationToken,
+                    decoration:
+                        const InputDecoration(labelText: "Registration Token"),
+                    validator: (v) =>
+                        (isPrivate && (v == null || v.isEmpty)) ? "Requerido" : null,
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: _invitationToken,
+                    decoration:
+                        const InputDecoration(labelText: "Invitation Token"),
+                  ),
+                ],
                 const SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: state is! AuthLoading
@@ -66,6 +87,14 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                                   name: _name.text.trim().isEmpty
                                       ? null
                                       : _name.text.trim(),
+                                  registrationToken:
+                                      _registrationToken.text.trim().isEmpty
+                                          ? null
+                                          : _registrationToken.text.trim(),
+                                  invitationToken:
+                                      _invitationToken.text.trim().isEmpty
+                                          ? null
+                                          : _invitationToken.text.trim(),
                                 );
                           }
                         }


### PR DESCRIPTION
## Summary
- add app mode provider
- handle registration and invitation tokens in register screen

## Testing
- `dart format lib/ui/screens/register_screen.dart lib/state/app_mode_provider.dart` (fail: command not found)
- `dart analyze` (fail: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b86ac3e3088324a603961a2ee88ebc