### PR TITLE
Centralize invitations and payments routes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,9 +20,7 @@ import 'ui/screens/recurring_payments/recurring_payments_screen.dart';
 import 'ui/screens/reports/reports_screen.dart';
 import 'ui/screens/payments/payment_list_screen.dart';
 import 'ui/screens/invitations/invitation_list_screen.dart';
-import 'ui/screens/invitations/invitation_list_screen.dart';
 import 'ui/screens/invitations/invitation_accept_screen.dart';
-import 'ui/screens/payments/payment_list_screen.dart';
 import 'ui/screens/payments/payment_form_screen.dart';
 import 'ui/screens/payments/payment_approval_screen.dart';
 
@@ -90,19 +88,16 @@ class MyApp extends StatelessWidget {
         GoRoute(
             path: AppRoutes.invitationAccept,
             builder: (_, __) => const InvitationAcceptScreen()),
-
         GoRoute(
-            path: '/groups/:id/payments',
+            path: AppRoutes.payments,
             builder: (_, state) =>
                 PaymentListScreen(groupId: state.pathParameters['id']!)),
         GoRoute(
-            path: '/invitations',
-            builder: (_, __) => const InvitationListScreen()),
-            path: '/groups/:id/payments/new',
+            path: AppRoutes.paymentForm,
             builder: (_, state) =>
                 PaymentFormScreen(groupId: state.pathParameters['id']!)),
         GoRoute(
-            path: '/groups/:id/payments/:payId',
+            path: AppRoutes.paymentDetail,
             builder: (_, state) =>
                 PaymentApprovalScreen(id: state.pathParameters['payId']!)),
       ],

--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -12,8 +12,6 @@ class AppRoutes {
   static const notifications = '/notifications';
   static const recurringPayments = '/recurring-payments';
   static const reports = '/reports';
-  static const payments = '/groups/:id/payments';
-  static const invitations = '/invitations';
   static const invitations = '/invitations';
   static const invitationAccept = '/invitations/accept';
   static const groupMembers = '/groups/:id/members';

--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -17,41 +17,37 @@ class DashboardScreen extends StatelessWidget {
           )
         ],
       ),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ElevatedButton(
-              onPressed: () => context.push('/groups'),
-              child: const Text('Ver grupos'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/notifications'),
-              child: const Text('Notificaciones'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/recurring-payments'),
-              child: const Text('Pagos recurrentes'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/reports'),
-              child: const Text('Reportes'),
-            ),
-          ],
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () => context.push('/invitations'),
-              child: const Text('Ver invitaciones'),
-            ),
-          ],
-        child: ElevatedButton(
-          onPressed: () => context.push(AppRoutes.groups),
-          child: const Text('Ver grupos'),
+        body: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ElevatedButton(
+                onPressed: () => context.push(AppRoutes.groups),
+                child: const Text('Ver grupos'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () => context.push('/notifications'),
+                child: const Text('Notificaciones'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () => context.push('/recurring-payments'),
+                child: const Text('Pagos recurrentes'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () => context.push('/reports'),
+                child: const Text('Reportes'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => context.push(AppRoutes.invitations),
+                child: const Text('Ver invitaciones'),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
-}


### PR DESCRIPTION
## Summary
- remove duplicated `invitations` and `payments` constants in `AppRoutes`
- switch router and dashboard to use the centralized route names

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ac56114832485cd02ba2a342d63