### PR TITLE
Specify explicit NDK version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.example.ssds_app"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- pin Android NDK version in Gradle script to 27.0.12077973

## Testing
- `flutter test` *(fails: command not found)*
- `cd android && ./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ad6b55483249f6843dd051b4ec7