### PR TITLE
Fix payments route and remove duplicate invitation route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,8 +96,6 @@ class MyApp extends StatelessWidget {
             builder: (_, state) =>
                 PaymentListScreen(groupId: state.pathParameters['id']!)),
         GoRoute(
-            path: '/invitations',
-            builder: (_, __) => const InvitationListScreen()),
             path: '/groups/:id/payments/new',
             builder: (_, state) =>
                 PaymentFormScreen(groupId: state.pathParameters['id']!)),


### PR DESCRIPTION
## Summary
- wrap payment creation route with GoRoute and keep route list consistent
- remove duplicate `/invitations` route

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ad9bc0c832486fee0d528bb5c05