### PR TITLE
Remove duplicate route definitions

### DIFF
--- a/lib/ui/routes.dart
+++ b/lib/ui/routes.dart
@@ -12,8 +12,6 @@ class AppRoutes {
   static const notifications = '/notifications';
   static const recurringPayments = '/recurring-payments';
   static const reports = '/reports';
-  static const payments = '/groups/:id/payments';
-  static const invitations = '/invitations';
   static const invitations = '/invitations';
   static const invitationAccept = '/invitations/accept';
   static const groupMembers = '/groups/:id/members';


### PR DESCRIPTION
## Summary
- remove duplicated `invitations` route constant
- eliminate extra `payments` route constant

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b86adb9cc08324a1d1f4fbc0207b22