### PR TITLE
Refactor payment methods and remove duplicate imports

### DIFF
--- a/lib/repositories/payment_repository.dart
+++ b/lib/repositories/payment_repository.dart
@@ -1,5 +1,3 @@
-import "../models/payment.dart";
-import "../services/payment_service.dart";
 import '../models/payment.dart';
 import '../services/payment_service.dart';
 
@@ -7,15 +5,6 @@ class PaymentRepository {
   final PaymentService _service;
   PaymentRepository(this._service);
 
-  Future<List<Payment>> fetchPayments(String groupId) =>
-      _service.getPayments(groupId: groupId);
-
-  Future<Payment> createPayment(
-    String groupId,
-    String fromUserId,
-    String toUserId,
-    double amount, {
-    String? description,
   Future<List<Payment>> getPayments({
     String? groupId,
     String? status,
@@ -45,7 +34,6 @@ class PaymentRepository {
         fromUserId: fromUserId,
         toUserId: toUserId,
         amount: amount,
-        note: description,
         note: note,
         evidenceUrl: evidenceUrl,
         paymentMethod: paymentMethod,
@@ -60,4 +48,3 @@ class PaymentRepository {
 
   Future<void> deletePayment(String id) => _service.deletePayment(id);
 }
-

--- a/lib/state/payments/payment_provider.dart
+++ b/lib/state/payments/payment_provider.dart
@@ -1,10 +1,6 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:dio/dio.dart';
-import '../../config/locator.dart';
-import '../../repositories/payment_repository.dart';
-import '../../models/payment.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../config/locator.dart';
 import '../../models/payment.dart';
 import '../../repositories/payment_repository.dart';
@@ -17,17 +13,6 @@ final paymentNotifierProvider =
 
 class PaymentNotifier extends StateNotifier<PaymentState> {
   final PaymentRepository _repo;
-  PaymentNotifier(this._repo) : super(PaymentState.initial());
-
-  Future<void> fetchPayments(String groupId) async {
-    state = state.copyWith(isLoading: true, error: null);
-    try {
-      final payments = await _repo.fetchPayments(groupId);
-      state = state.copyWith(payments: payments, isLoading: false);
-    } on DioException catch (e) {
-      state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
-
   PaymentNotifier(this._repo) : super(PaymentState.initial());
 
   Future<void> fetchPayments({
@@ -57,27 +42,6 @@ class PaymentNotifier extends StateNotifier<PaymentState> {
     }
   }
 
-  Future<void> createPayment(
-    String groupId,
-    String fromUserId,
-    String toUserId,
-    double amount, {
-    String? description,
-  }) async {
-    state = state.copyWith(isLoading: true, error: null);
-    try {
-      await _repo.createPayment(
-        groupId,
-        fromUserId,
-        toUserId,
-        amount,
-        description: description,
-      );
-      final payments = await _repo.fetchPayments(groupId);
-      state = state.copyWith(payments: payments, isLoading: false);
-    } on DioException catch (e) {
-      state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
   Future<void> addPayment({
     required String groupId,
     required String fromUserId,
@@ -112,23 +76,13 @@ class PaymentNotifier extends StateNotifier<PaymentState> {
     }
   }
 
-  Future<void> approvePayment(String id, String groupId) async {
-    state = state.copyWith(isLoading: true, error: null);
-    try {
-      await _repo.approvePayment(id);
-      final payments = await _repo.fetchPayments(groupId);
-      state = state.copyWith(payments: payments, isLoading: false);
-    } on DioException catch (e) {
-      state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
   Future<void> approvePayment(String id) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
       final updated = await _repo.approvePayment(id);
       state = state.copyWith(
-        payments: state.payments
-            .map((p) => p.id == id ? updated : p)
-            .toList(),
+        payments:
+            state.payments.map((p) => p.id == id ? updated : p).toList(),
         isLoading: false,
       );
     } on DioException catch (e) {
@@ -141,23 +95,13 @@ class PaymentNotifier extends StateNotifier<PaymentState> {
     }
   }
 
-  Future<void> rejectPayment(String id, String groupId) async {
-    state = state.copyWith(isLoading: true, error: null);
-    try {
-      await _repo.rejectPayment(id);
-      final payments = await _repo.fetchPayments(groupId);
-      state = state.copyWith(payments: payments, isLoading: false);
-    } on DioException catch (e) {
-      state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
   Future<void> rejectPayment(String id) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
       final updated = await _repo.rejectPayment(id);
       state = state.copyWith(
-        payments: state.payments
-            .map((p) => p.id == id ? updated : p)
-            .toList(),
+        payments:
+            state.payments.map((p) => p.id == id ? updated : p).toList(),
         isLoading: false,
       );
     } on DioException catch (e) {
@@ -169,7 +113,6 @@ class PaymentNotifier extends StateNotifier<PaymentState> {
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }
-}
 
   Payment? getById(String id) {
     try {
@@ -179,4 +122,3 @@ class PaymentNotifier extends StateNotifier<PaymentState> {
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- remove duplicate imports in payment repository and provider
- unify payment retrieval and creation methods with `note` parameter
- clean up braces and update provider logic

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86add4b4c832480ba4f2f12238728