### PR TITLE
fix extra useEffect closure in invitation list screen

### DIFF
--- a/lib/ui/screens/invitations/invitation_list_screen.dart
+++ b/lib/ui/screens/invitations/invitation_list_screen.dart
@@ -15,7 +15,6 @@ class InvitationListScreen extends HookConsumerWidget {
       ref.read(invitationNotifierProvider.notifier).fetchInvitations();
       return null;
     }, const []);
-    }, []);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Invitaciones')),


### PR DESCRIPTION
## Summary
- remove redundant useEffect closure in invitation list screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86addfeb083248b4ccc5ab2920e23