### PR TITLE
Fix invitation acceptance provider

### DIFF
--- a/lib/state/invitations/invitation_provider.dart
+++ b/lib/state/invitations/invitation_provider.dart
@@ -21,7 +21,6 @@ class InvitationNotifier extends StateNotifier<InvitationState> {
       state = state.copyWith(invitations: invitations, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
         isLoading: false,
         error: e.response?.data['message'] ?? e.message,
       );
@@ -30,10 +29,6 @@ class InvitationNotifier extends StateNotifier<InvitationState> {
     }
   }
 
-  Future<void> acceptInvitation(String invitationId) async {
-    state = state.copyWith(isLoading: true, error: null);
-    try {
-      await _repo.acceptInvitation(invitationId);
   Future<void> acceptInvitation(String token) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
@@ -42,7 +37,6 @@ class InvitationNotifier extends StateNotifier<InvitationState> {
       state = state.copyWith(invitations: invitations, isLoading: false);
     } on DioException catch (e) {
       state = state.copyWith(
-          isLoading: false, error: e.response?.data['message'] ?? e.message);
         isLoading: false,
         error: e.response?.data['message'] ?? e.message,
       );

--- a/lib/ui/screens/invitations/invitation_list_screen.dart
+++ b/lib/ui/screens/invitations/invitation_list_screen.dart
@@ -15,7 +15,6 @@ class InvitationListScreen extends HookConsumerWidget {
       ref.read(invitationNotifierProvider.notifier).fetchInvitations();
       return null;
     }, const []);
-    }, []);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Invitaciones')),


### PR DESCRIPTION
## Summary
- consolidate `acceptInvitation` into a single token-based method
- clean error handling for invitations provider and list screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ade1d0883249c7a8b2458dcb008