### PR TITLE
Refactor payment list tile and actions

### DIFF
--- a/lib/ui/screens/payments/payment_list_screen.dart
+++ b/lib/ui/screens/payments/payment_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../../../state/payments/payment_provider.dart';
+import '../../../models/payment.dart';
 
 class PaymentListScreen extends HookConsumerWidget {
   final String groupId;
@@ -14,8 +15,9 @@ class PaymentListScreen extends HookConsumerWidget {
     final state = ref.watch(paymentNotifierProvider);
 
     useEffect(() {
-      ref.read(paymentNotifierProvider.notifier).fetchPayments(groupId);
-      ref.read(paymentNotifierProvider.notifier).fetchPayments(groupId: groupId);
+      ref
+          .read(paymentNotifierProvider.notifier)
+          .fetchPayments(groupId: groupId);
       return null;
     }, [groupId]);
 
@@ -30,11 +32,9 @@ class PaymentListScreen extends HookConsumerWidget {
                   itemBuilder: (_, index) {
                     final payment = state.payments[index];
                     return ListTile(
-                      title: Text(
-                          '${payment.fromUserId} → ${payment.toUserId}'),
-                      subtitle:
-                          Text('\$${payment.amount.toStringAsFixed(2)}'),
-                      trailing: payment.status == 'pending'
+                      title: Text('\$${payment.amount.toStringAsFixed(2)}'),
+                      subtitle: Text(payment.note ?? ''),
+                      trailing: payment.status == PaymentStatus.pending
                           ? Row(
                               mainAxisSize: MainAxisSize.min,
                               children: [
@@ -52,19 +52,13 @@ class PaymentListScreen extends HookConsumerWidget {
                                 ),
                               ],
                             )
-                          : Text(payment.status),
-                      title: Text('\\$${payment.amount.toStringAsFixed(2)}'),
-                      subtitle: Text(payment.note ?? ''),
-                      trailing: Text(payment.status.name),
-                      onTap: () => context.push(
-                          '/groups/$groupId/payments/${payment.id}'),
+                          : Text(payment.status.name),
+                      onTap: () =>
+                          context.push('/groups/$groupId/payments/${payment.id}'),
                     );
                   },
                 ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          // Placeholder for payment creation
-        },
         onPressed: () => context.push('/groups/$groupId/payments/new'),
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
## Summary
- Remove duplicate fetchPayments call and use named argument
- Simplify ListTile to single title/subtitle/trailing and show status name
- Use PaymentStatus enum for pending actions and clean FloatingActionButton handler

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ade83048324ab912ee08c0a77b8