### PR TITLE
Fix currency formatting for expense list subtitle

### DIFF
--- a/lib/ui/screens/expenses/expense_list_screen.dart
+++ b/lib/ui/screens/expenses/expense_list_screen.dart
@@ -29,7 +29,7 @@ class ExpenseListScreen extends HookConsumerWidget {
                     final expense = state.expenses[index];
                     return ListTile(
                       title: Text(expense.description),
-                      subtitle: Text('\\$${expense.amount.toStringAsFixed(2)}'),
+                      subtitle: Text('\$${expense.amount.toStringAsFixed(2)}'),
                       onTap: () =>
                           context.push('/groups/$groupId/expenses/${expense.id}'),
                     );


### PR DESCRIPTION
## Summary
- ensure expense list shows dollar sign with amount fixed to two decimals

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ae168ec83248cc8479f267fab10