### PR TITLE
Add auth state imports to screens

### DIFF
--- a/lib/ui/screens/login_screen.dart
+++ b/lib/ui/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "../../state/auth/auth_provider.dart";
+import "../../state/auth/auth_state.dart";
 import "package:go_router/go_router.dart";
 import "../routes.dart";
 

--- a/lib/ui/screens/profile_screen.dart
+++ b/lib/ui/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import "package:flutter/material.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../state/auth/auth_provider.dart";
+import "../../state/auth/auth_state.dart";
 
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});

--- a/lib/ui/screens/register_screen.dart
+++ b/lib/ui/screens/register_screen.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:go_router/go_router.dart";
 
 import "../../state/auth/auth_provider.dart";
+import "../../state/auth/auth_state.dart";
 import "../routes.dart";
 
 class RegisterScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- import auth_state in login, register, and profile screens so Auth* types resolve

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ae330ac8324a062ed5025c0c6f9