### PR TITLE
Fix group detail actions and enforce non-null id

### DIFF
--- a/lib/ui/screens/groups/group_detail_screen.dart
+++ b/lib/ui/screens/groups/group_detail_screen.dart
@@ -37,14 +37,14 @@ class GroupDetailScreen extends HookConsumerWidget {
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                          Text('ID: ${group.id}'),
+                          Text('ID: ${group!.id}'),
                           Text('Nombre: ${group.name}'),
                           if (group.description != null)
                             Text('Descripción: ${group.description}'),
                           const SizedBox(height: 20),
                           ElevatedButton(
                             onPressed: () =>
-                                context.push('/groups/${group.id}/expenses'),
+                                context.push('/groups/${group!.id}/expenses'),
                             child: const Text('Ver gastos'),
                           ),
                           const SizedBox(height: 8),
@@ -52,18 +52,19 @@ class GroupDetailScreen extends HookConsumerWidget {
                           const SizedBox(height: 10),
                           ElevatedButton(
                             onPressed: () =>
-                                context.push('/groups/${group.id}/members'),
+                                context.push('/groups/${group!.id}/members'),
                             child: const Text('Gestionar miembros'),
                           ),
                           const SizedBox(height: 10),
                           ElevatedButton(
                             onPressed: () =>
-                                context.push('/groups/${group.id}/balances'),
+                                context.push('/groups/${group!.id}/balances'),
                             child: const Text('Ver balances'),
+                          ),
                           const SizedBox(height: 12),
                           ElevatedButton(
                             onPressed: () =>
-                                context.push('/groups/${group.id}/payments'),
+                                context.push('/groups/${group!.id}/payments'),
                             child: const Text('Ver pagos'),
 
                           ),


### PR DESCRIPTION
## Summary
- fix 'Ver balances' button closure and add spacing between actions
- ensure group id is accessed as non-null

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ae3320c83249dc73c6888f81197