### PR TITLE
Fix payment routes and cleanup router

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,7 +109,6 @@ class MyApp extends ConsumerWidget {
             builder: (_, state) =>
                 PaymentListScreen(groupId: state.pathParameters['id']!)),
         GoRoute(
-            path: '/groups/:id/payments/new',
             path: AppRoutes.paymentForm,
             builder: (_, state) =>
                 PaymentFormScreen(groupId: state.pathParameters['id']!)),
@@ -118,21 +117,6 @@ class MyApp extends ConsumerWidget {
             builder: (_, state) =>
                 PaymentApprovalScreen(id: state.pathParameters['payId']!)),
       ],
-    );
-
-          GoRoute(
-              path: '/groups/:id/payments',
-              builder: (_, state) =>
-                  PaymentListScreen(groupId: state.pathParameters['id']!)),
-          GoRoute(
-              path: '/groups/:id/payments/new',
-              builder: (_, state) =>
-                  PaymentFormScreen(groupId: state.pathParameters['id']!)),
-          GoRoute(
-              path: '/groups/:id/payments/:payId',
-              builder: (_, state) =>
-                  PaymentApprovalScreen(id: state.pathParameters['payId']!)),
-        ],
       );
 
       return MaterialApp.router(


### PR DESCRIPTION
## Summary
- remove duplicated payment routes outside router
- keep single path definition for payment form route

## Testing
- `dart format lib/main.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b877b5a280832492078160a70e481b