### PR TITLE
Refactor payment tile handling

### DIFF
--- a/lib/ui/screens/payments/payment_list_screen.dart
+++ b/lib/ui/screens/payments/payment_list_screen.dart
@@ -52,12 +52,6 @@ class PaymentListScreen extends HookConsumerWidget {
                                 ),
                               ],
                             )
-                          : Text(payment.status),
-                      title: Text('\$${payment.amount.toStringAsFixed(2)}'),
-                      subtitle: Text(payment.note ?? ''),
-                      trailing: Text(payment.status.name),
-                      onTap: () => context.push(
-                          '/groups/$groupId/payments/${payment.id}'),
                           : Text(payment.status.name),
                       onTap: () =>
                           context.push('/groups/$groupId/payments/${payment.id}'),


### PR DESCRIPTION
## Summary
- remove duplicate title, subtitle and trailing definitions in payment list tile
- handle trailing display using PaymentStatus.name and action row when pending

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b877ec8c4c83248cd4b9ee48040cf9