### PR TITLE
Eliminate duplicate token parameters in register call

### DIFF
--- a/lib/ui/screens/register_screen.dart
+++ b/lib/ui/screens/register_screen.dart
@@ -95,8 +95,6 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                                   name: _name.text.trim().isEmpty
                                       ? null
                                       : _name.text.trim(),
-                                  registrationToken: widget.registrationToken,
-                                  invitationToken: widget.invitationToken,
                                   registrationToken:
                                       _registrationToken.text.trim().isEmpty
                                           ? null


### PR DESCRIPTION
## Summary
- Remove duplicate `registrationToken` and `invitationToken` parameters in `RegisterScreen`'s register call

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b877ef8b448324a410a4f15da3c1ae