### PR TITLE
Close Scaffold widget hierarchy in dashboard screen

### DIFF
--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -41,8 +41,8 @@ class DashboardScreen extends StatelessWidget {
               child: const Text('Reportes'),
             ),
           ],
-
         ),
-      );
-    }
+      ),
+    );
   }
+}


### PR DESCRIPTION
## Summary
- properly close Column, Center, and Scaffold widgets in `DashboardScreen`

## Testing
- `dart format lib/ui/screens/dashboard_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87805f17c832491f25574a1f6dd0f