### PR TITLE
Add profile UI prototype and reusable navigation bar

### DIFF
--- a/lib/ui/prototypes/dashboard_page.dart
+++ b/lib/ui/prototypes/dashboard_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/app_bottom_navigation.dart';
+
 const softSage = Color(0xFFE8EAE6);
 const lightLavender = Color(0xFFE6E6FA);
 const textSecondary = Color(0xFF6B7280);
@@ -37,18 +39,7 @@ class DashboardPage extends StatelessWidget {
           _activityTile('Alquiler', 'Sophia pagó su parte.', '4h'),
         ],
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: 1,
-        items: [
-          BottomNavigationBarItem(icon: Icon(Icons.groups), label: 'Grupos'),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.dashboard),
-            label: 'Dashboard',
-          ),
-          BottomNavigationBarItem(icon: Icon(Icons.payments), label: 'Pagos'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
-        ],
-      ),
+      bottomNavigationBar: const AppBottomNavigation(currentIndex: 1),
     );
   }
 

--- a/lib/ui/prototypes/edit_profile_page.dart
+++ b/lib/ui/prototypes/edit_profile_page.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/app_bottom_navigation.dart';
+
+class EditProfilePage extends StatelessWidget {
+  const EditProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Editar perfil')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Center(
+            child: Column(
+              children: const [
+                CircleAvatar(
+                  radius: 40,
+                  backgroundImage: NetworkImage(
+                    'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e',
+                  ),
+                ),
+                SizedBox(height: 12),
+                Text('Sofia Ramirez',
+                    style:
+                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+                SizedBox(height: 16),
+              ],
+            ),
+          ),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Nombre'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Correo electrónico'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Teléfono'),
+            keyboardType: TextInputType.phone,
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Ubicación'),
+          ),
+          const SizedBox(height: 12),
+          TextField(
+            decoration: const InputDecoration(labelText: 'Idioma'),
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: () {},
+            child: const Text('Guardar cambios'),
+          )
+        ],
+      ),
+      bottomNavigationBar: const AppBottomNavigation(currentIndex: 3),
+    );
+  }
+}

--- a/lib/ui/prototypes/groups_page.dart
+++ b/lib/ui/prototypes/groups_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../widgets/app_bottom_navigation.dart';
+
 const lightGray = Color(0xFFF5F5F5);
 const blueishGray = Color(0xFF7C8B9A);
 
@@ -68,18 +70,7 @@ class GroupsPage extends StatelessWidget {
           );
         },
       ),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: 0,
-        items: [
-          BottomNavigationBarItem(icon: Icon(Icons.groups), label: 'Grupos'),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.bar_chart),
-            label: 'Dashboard',
-          ),
-          BottomNavigationBarItem(icon: Icon(Icons.payments), label: 'Pagos'),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
-        ],
-      ),
+      bottomNavigationBar: const AppBottomNavigation(currentIndex: 0),
     );
   }
 }

--- a/lib/ui/prototypes/profile_page.dart
+++ b/lib/ui/prototypes/profile_page.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../widgets/app_bottom_navigation.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Perfil')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const SizedBox(height: 24),
+          Center(
+            child: Column(
+              children: [
+                const CircleAvatar(
+                  radius: 40,
+                  backgroundImage: NetworkImage(
+                    'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                const Text(
+                  'Sofia Rodriguez',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                ),
+                const Text('sofia_rodriguez@email.com',
+                    style: TextStyle(color: Colors.grey)),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Editar perfil'),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 24),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.home),
+              title: const Text('Dirección'),
+              subtitle: const Text('123 Calle Principal, Ciudad'),
+              onTap: () {},
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.phone),
+              title: const Text('Teléfono'),
+              subtitle: const Text('+52 123 456 7890'),
+              onTap: () {},
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.language),
+              title: const Text('Idioma'),
+              subtitle: const Text('Español'),
+              onTap: () {},
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: const AppBottomNavigation(currentIndex: 3),
+    );
+  }
+}

--- a/lib/ui/widgets/app_bottom_navigation.dart
+++ b/lib/ui/widgets/app_bottom_navigation.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../routes.dart';
+
+/// Bottom navigation bar used across main pages.
+class AppBottomNavigation extends StatelessWidget {
+  final int currentIndex;
+  const AppBottomNavigation({super.key, required this.currentIndex});
+
+  void _onItemTapped(BuildContext context, int index) {
+    switch (index) {
+      case 0:
+        context.go(AppRoutes.groups);
+        break;
+      case 1:
+        context.go(AppRoutes.dashboard);
+        break;
+      case 2:
+        context.go('/payments');
+        break;
+      case 3:
+        context.go(AppRoutes.profile);
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: (i) => _onItemTapped(context, i),
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.groups), label: 'Grupos'),
+        BottomNavigationBarItem(icon: Icon(Icons.dashboard), label: 'Dashboard'),
+        BottomNavigationBarItem(icon: Icon(Icons.payments), label: 'Pagos'),
+        BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add reusable `AppBottomNavigation` widget for consistent navigation
- Implement profile and edit-profile prototype screens
- Update dashboard and groups prototypes to use shared navigation bar

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba23d7327c832495a4386e697258c5