### PR TITLE
Refactor app mode provider usage and cleanup

### DIFF
--- a/lib/services/app_service.dart
+++ b/lib/services/app_service.dart
@@ -8,29 +8,9 @@ class AppService {
 
   Future<String> getAppMode() async {
     try {
-      print("Intentando obtener app-mode...");
-
-      // Prueba directa con HTTP
-      try {
-        final uri = Uri.parse("http://10.10.10.203/api/app-mode");
-        print("Probando HTTP directo a: $uri");
-        final httpResponse = await Dio().get(uri.toString());
-        print("Respuesta HTTP directa: ${httpResponse.data}");
-      } catch (e) {
-        print("Error en HTTP directo: $e");
-      }
-
       final res = await _client.get("/app-mode");
-      print("Respuesta recibida: ${res.data}");
-      return res.data["mode_app"] as String;
+      return res.data["mode"] as String;
     } on DioException catch (e) {
-      print("Error tipo: ${e.type}");
-      print("Error mensaje: ${e.message}");
-      print("Error response: ${e.response}");
-      if (e.response != null) {
-        print("Error status code: ${e.response?.statusCode}");
-        print("Error data: ${e.response?.data}");
-      }
       throw Exception(e.response?.data["message"] ?? e.message);
     }
   }

--- a/lib/state/app_mode_provider.dart
+++ b/lib/state/app_mode_provider.dart
@@ -1,6 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-/// Provides the current application mode, either `public` or `private`.
-/// Defaults to `public`.
-final appModeProvider = Provider<String>((ref) => 'public');
-

--- a/lib/ui/screens/register_screen.dart
+++ b/lib/ui/screens/register_screen.dart
@@ -4,7 +4,7 @@ import "package:go_router/go_router.dart";
 
 import "../../state/auth/auth_provider.dart";
 import "../../state/auth/auth_state.dart";
-import "../../state/app_mode_provider.dart";
+import "../../state/app_mode/app_mode_provider.dart";
 import "../routes.dart";
 
 class RegisterScreen extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary
- remove direct HTTP call and debug prints in AppService and read `mode` key
- delete duplicate app mode provider file and use central provider in register screen
- show registration token fields only when app mode is private

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c07fde88324a6e03f6b3f973645