### PR TITLE
Use snake_case JSON keys across models and services

### DIFF
--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -19,19 +19,26 @@ class Group {
         id: json['id'].toString(),
         name: json['name'] ?? '',
         description: json['description'],
-        createdBy: json['createdBy']?.toString(),
-        createdAt:
-            json['createdAt'] != null ? DateTime.parse(json['createdAt']) : null,
-        updatedAt:
-            json['updatedAt'] != null ? DateTime.parse(json['updatedAt']) : null,
+        createdBy:
+            json['created_by']?.toString() ?? json['createdBy']?.toString(),
+        createdAt: json['created_at'] != null
+            ? DateTime.parse(json['created_at'])
+            : json['createdAt'] != null
+                ? DateTime.parse(json['createdAt'])
+                : null,
+        updatedAt: json['updated_at'] != null
+            ? DateTime.parse(json['updated_at'])
+            : json['updatedAt'] != null
+                ? DateTime.parse(json['updatedAt'])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,
         'description': description,
-        'createdBy': createdBy,
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
+        'created_by': createdBy,
+        'created_at': createdAt?.toIso8601String(),
+        'updated_at': updatedAt?.toIso8601String(),
       };
 }

--- a/lib/models/invitation.dart
+++ b/lib/models/invitation.dart
@@ -19,26 +19,32 @@ class Invitation {
 
   factory Invitation.fromJson(Map<String, dynamic> json) => Invitation(
         id: json['id'].toString(),
-        groupId: json['groupId'].toString(),
+        groupId:
+            json['group_id']?.toString() ?? json['groupId'].toString(),
         email: json['email'] ?? '',
         status: json['status'] ?? '',
-        invitedBy: json['invitedBy']?.toString(),
-        createdAt: json['createdAt'] != null
-            ? DateTime.parse(json['createdAt'])
-            : null,
-        updatedAt: json['updatedAt'] != null
-            ? DateTime.parse(json['updatedAt'])
-            : null,
+        invitedBy:
+            json['invited_by']?.toString() ?? json['invitedBy']?.toString(),
+        createdAt: json['created_at'] != null
+            ? DateTime.parse(json['created_at'])
+            : json['createdAt'] != null
+                ? DateTime.parse(json['createdAt'])
+                : null,
+        updatedAt: json['updated_at'] != null
+            ? DateTime.parse(json['updated_at'])
+            : json['updatedAt'] != null
+                ? DateTime.parse(json['updatedAt'])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'groupId': groupId,
+        'group_id': groupId,
         'email': email,
         'status': status,
-        'invitedBy': invitedBy,
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
+        'invited_by': invitedBy,
+        'created_at': createdAt?.toIso8601String(),
+        'updated_at': updatedAt?.toIso8601String(),
       };
 }
 

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -17,17 +17,20 @@ class AppNotification {
         id: json['id'].toString(),
         title: json['title'] ?? '',
         body: json['body'] ?? '',
-        isRead: json['isRead'] ?? json['read'] ?? false,
-        createdAt: json['createdAt'] != null
-            ? DateTime.parse(json['createdAt'])
-            : null,
+        isRead:
+            json['is_read'] ?? json['isRead'] ?? json['read'] ?? false,
+        createdAt: json['created_at'] != null
+            ? DateTime.parse(json['created_at'])
+            : json['createdAt'] != null
+                ? DateTime.parse(json['createdAt'])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
         'title': title,
         'body': body,
-        'isRead': isRead,
-        'createdAt': createdAt?.toIso8601String(),
+        'is_read': isRead,
+        'created_at': createdAt?.toIso8601String(),
       };
 }

--- a/lib/models/payment.dart
+++ b/lib/models/payment.dart
@@ -29,34 +29,43 @@ class Payment {
 
   factory Payment.fromJson(Map<String, dynamic> json) => Payment(
         id: json['id'].toString(),
-        groupId: json['groupId'].toString(),
-        fromUserId: json['fromUserId'].toString(),
-        toUserId: json['toUserId'].toString(),
+        groupId:
+            json['group_id']?.toString() ?? json['groupId'].toString(),
+        fromUserId: json['from_user_id']?.toString() ??
+            json['fromUserId'].toString(),
+        toUserId:
+            json['to_user_id']?.toString() ?? json['toUserId'].toString(),
         amount: (json['amount'] as num?)?.toDouble() ?? 0,
         note: json['note']?.toString(),
-        evidenceUrl: json['evidenceUrl']?.toString(),
-        paymentMethod: json['paymentMethod']?.toString(),
+        evidenceUrl:
+            json['evidence_url']?.toString() ?? json['evidenceUrl']?.toString(),
+        paymentMethod: json['payment_method']?.toString() ??
+            json['paymentMethod']?.toString(),
         status: _statusFromString(json['status'] ?? ''),
-        createdAt: json['createdAt'] != null
-            ? DateTime.parse(json['createdAt'])
-            : null,
-        updatedAt: json['updatedAt'] != null
-            ? DateTime.parse(json['updatedAt'])
-            : null,
+        createdAt: json['created_at'] != null
+            ? DateTime.parse(json['created_at'])
+            : json['createdAt'] != null
+                ? DateTime.parse(json['createdAt'])
+                : null,
+        updatedAt: json['updated_at'] != null
+            ? DateTime.parse(json['updated_at'])
+            : json['updatedAt'] != null
+                ? DateTime.parse(json['updatedAt'])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'groupId': groupId,
-        'fromUserId': fromUserId,
-        'toUserId': toUserId,
+        'group_id': groupId,
+        'from_user_id': fromUserId,
+        'to_user_id': toUserId,
         'amount': amount,
         if (note != null) 'note': note,
-        if (evidenceUrl != null) 'evidenceUrl': evidenceUrl,
-        if (paymentMethod != null) 'paymentMethod': paymentMethod,
+        if (evidenceUrl != null) 'evidence_url': evidenceUrl,
+        if (paymentMethod != null) 'payment_method': paymentMethod,
         'status': status.name,
-        'createdAt': createdAt?.toIso8601String(),
-        'updatedAt': updatedAt?.toIso8601String(),
+        'created_at': createdAt?.toIso8601String(),
+        'updated_at': updatedAt?.toIso8601String(),
       };
 }
 

--- a/lib/models/recurring_payment.dart
+++ b/lib/models/recurring_payment.dart
@@ -17,21 +17,24 @@ class RecurringPayment {
 
   factory RecurringPayment.fromJson(Map<String, dynamic> json) => RecurringPayment(
         id: json['id'].toString(),
-        groupId: json['groupId'].toString(),
+        groupId:
+            json['group_id']?.toString() ?? json['groupId'].toString(),
         description: json['description'] ?? '',
         amount: (json['amount'] as num?)?.toDouble() ?? 0,
         frequency: json['frequency'] ?? '',
-        nextDate: json['nextDate'] != null
-            ? DateTime.parse(json['nextDate'])
-            : null,
+        nextDate: json['next_date'] != null
+            ? DateTime.parse(json['next_date'])
+            : json['nextDate'] != null
+                ? DateTime.parse(json['nextDate'])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         'id': id,
-        'groupId': groupId,
+        'group_id': groupId,
         'description': description,
         'amount': amount,
         'frequency': frequency,
-        'nextDate': nextDate?.toIso8601String(),
+        'next_date': nextDate?.toIso8601String(),
       };
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -2,7 +2,7 @@ class User {
   final String id;
   final String email;
   final String? name;
-  final String? avatarUrl;
+  final String? profilePictureUrl;
   final String? phoneNumber;
   final DateTime? createdAt;
   final DateTime? updatedAt;
@@ -11,7 +11,7 @@ class User {
     required this.id,
     required this.email,
     this.name,
-    this.avatarUrl,
+    this.profilePictureUrl,
     this.phoneNumber,
     this.createdAt,
     this.updatedAt,
@@ -21,23 +21,30 @@ class User {
         id: json["id"].toString(),
         email: json["email"] ?? "",
         name: json["name"],
-        avatarUrl: json["avatarUrl"] ?? json["profilePictureUrl"],
-        phoneNumber: json["phoneNumber"] ?? json["phone_number"],
-        createdAt: json["createdAt"] != null
-            ? DateTime.parse(json["createdAt"])
-            : null,
-        updatedAt: json["updatedAt"] != null
-            ? DateTime.parse(json["updatedAt"])
-            : null,
+        profilePictureUrl: json["profile_picture_url"] ??
+            json["avatar_url"] ??
+            json["avatarUrl"] ??
+            json["profilePictureUrl"],
+        phoneNumber: json["phone_number"] ?? json["phoneNumber"],
+        createdAt: json["created_at"] != null
+            ? DateTime.parse(json["created_at"])
+            : json["createdAt"] != null
+                ? DateTime.parse(json["createdAt"])
+                : null,
+        updatedAt: json["updated_at"] != null
+            ? DateTime.parse(json["updated_at"])
+            : json["updatedAt"] != null
+                ? DateTime.parse(json["updatedAt"])
+                : null,
       );
 
   Map<String, dynamic> toJson() => {
         "id": id,
         "email": email,
         "name": name,
-        "avatarUrl": avatarUrl,
-        "phoneNumber": phoneNumber,
-        "createdAt": createdAt?.toIso8601String(),
-        "updatedAt": updatedAt?.toIso8601String(),
+        "profile_picture_url": profilePictureUrl,
+        "phone_number": phoneNumber,
+        "created_at": createdAt?.toIso8601String(),
+        "updated_at": updatedAt?.toIso8601String(),
       };
 }

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -62,7 +62,7 @@ class GroupService {
   Future<void> addMember(String groupId, String userId, {String? role}) async {
     try {
       await _client.post("/groups/$groupId/members", data: {
-        "userId": userId,
+        "user_id": userId,
         if (role != null) "role": role,
       });
     } on DioException catch (e) {

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -7,14 +7,14 @@ class InvitationService {
   final ApiClient _client;
   InvitationService(this._client);
 
-  /// GET /api/invitations[?mine=true][&groupId=UUID]
+  /// GET /api/invitations[?mine=true][&group_id=UUID]
   Future<List<Invitation>> getInvitations({bool? mine, String? groupId}) async {
     try {
       final res = await _client.get(
         "/invitations",
         query: {
           if (mine != null) "mine": mine.toString(),
-          if (groupId != null) "groupId": groupId,
+          if (groupId != null) "group_id": groupId,
         },
       );
       final data = res.data as List;

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -7,7 +7,7 @@ class PaymentService {
   final ApiClient _client;
   PaymentService(this._client);
 
-  /// GET /api/payments[?status][&direction][&groupId][&startDate][&endDate]
+  /// GET /api/payments[?status][&direction][&group_id][&start_date][&end_date]
   Future<List<Payment>> getPayments({
     String? groupId,
     String? status,     // "approved" | "pending" | "rejected"
@@ -17,11 +17,11 @@ class PaymentService {
   }) async {
     try {
       final res = await _client.get("/payments", query: {
-        if (groupId != null) "groupId": groupId,
+        if (groupId != null) "group_id": groupId,
         if (status != null) "status": status,
         if (direction != null) "direction": direction,
-        if (startDate != null) "startDate": startDate,
-        if (endDate != null) "endDate": endDate,
+        if (startDate != null) "start_date": startDate,
+        if (endDate != null) "end_date": endDate,
       });
       final data = res.data as List;
       return data.map((e) => Payment.fromJson(e)).toList();
@@ -31,7 +31,7 @@ class PaymentService {
   }
 
   /// POST /api/payments
-  /// Body: { groupId, fromUserId, toUserId, amount, note?, evidenceUrl?, paymentMethod? }
+  /// Body: { group_id, from_user_id, to_user_id, amount, note?, evidence_url?, payment_method? }
   Future<Payment> createPayment({
     required String groupId,
     required String fromUserId,
@@ -43,13 +43,13 @@ class PaymentService {
   }) async {
     try {
       final res = await _client.post("/payments", data: {
-        "groupId": groupId,
-        "fromUserId": fromUserId,
-        "toUserId": toUserId,
+        "group_id": groupId,
+        "from_user_id": fromUserId,
+        "to_user_id": toUserId,
         "amount": amount,
         if (note != null) "note": note,
-        if (evidenceUrl != null) "evidenceUrl": evidenceUrl,
-        if (paymentMethod != null) "paymentMethod": paymentMethod,
+        if (evidenceUrl != null) "evidence_url": evidenceUrl,
+        if (paymentMethod != null) "payment_method": paymentMethod,
       });
       return Payment.fromJson(res.data);
     } on DioException catch (e) {
@@ -86,13 +86,13 @@ class PaymentService {
     }
   }
 
-  /// GET /api/payments/due[?groupId]
+  /// GET /api/payments/due[?group_id]
   Future<List<Payment>> getDuePayments({String? groupId}) async {
     try {
       final res = await _client.get(
         "/payments/due",
         query: {
-          if (groupId != null) "groupId": groupId,
+          if (groupId != null) "group_id": groupId,
         },
       );
       final data = res.data as List;

--- a/lib/services/recurring_payment_service.dart
+++ b/lib/services/recurring_payment_service.dart
@@ -10,7 +10,7 @@ class RecurringPaymentService {
   Future<List<RecurringPayment>> getRecurringPayments({String? groupId}) async {
     try {
       final res = await _client.get('/recurring-payments', query: {
-        if (groupId != null) 'groupId': groupId,
+        if (groupId != null) 'group_id': groupId,
       });
       final data = res.data as List;
       return data.map((e) => RecurringPayment.fromJson(e)).toList();
@@ -27,7 +27,7 @@ class RecurringPaymentService {
   }) async {
     try {
       final res = await _client.post('/recurring-payments', data: {
-        'groupId': groupId,
+        'group_id': groupId,
         'description': description,
         'amount': amount,
         'frequency': frequency,
@@ -48,7 +48,7 @@ class RecurringPaymentService {
         if (description != null) 'description': description,
         if (amount != null) 'amount': amount,
         if (frequency != null) 'frequency': frequency,
-        if (nextDate != null) 'nextDate': nextDate.toIso8601String(),
+        if (nextDate != null) 'next_date': nextDate.toIso8601String(),
       });
       return RecurringPayment.fromJson(res.data);
     } on DioException catch (e) {


### PR DESCRIPTION
## Summary
- normalize JSON serialization to snake_case for core models
- send and read snake_case fields in group, invitation, payment and recurring payment services

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c15d0948324a637048469efb08b