### PR TITLE
Use camelCase query params in ExpenseService

### DIFF
--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -11,9 +11,9 @@ class ExpenseService {
       {DateTime? startDate, DateTime? endDate}) async {
     try {
       final params = {
-        "group_id": groupId,
-        if (startDate != null) "start_date": startDate.toIso8601String(),
-        if (endDate != null) "end_date": endDate.toIso8601String(),
+        "groupId": groupId,
+        if (startDate != null) "startDate": startDate.toIso8601String(),
+        if (endDate != null) "endDate": endDate.toIso8601String(),
       };
       final res = await _client.get("/expenses", query: params);
       final data = res.data as List;


### PR DESCRIPTION
## Summary
- switch expense query param names to camelCase (groupId, startDate, endDate)

## Testing
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c2cc0d8832491faf1d206bf6263