### PR TITLE
Add support for fetching and approving individual expenses

### DIFF
--- a/lib/repositories/expense_repository.dart
+++ b/lib/repositories/expense_repository.dart
@@ -19,6 +19,9 @@ class ExpenseRepository {
     );
   }
 
+  /// Retrieve a single expense by its identifier.
+  Future<Expense> getExpense(String id) => _service.getExpense(id);
+
   /// Create a new expense in the given group.
   Future<Expense> createExpense(
     String groupId,
@@ -64,6 +67,9 @@ class ExpenseRepository {
       participants: participants,
     );
   }
+
+  /// Approve an expense by its identifier.
+  Future<Expense> approveExpense(String id) => _service.approveExpense(id);
 
   /// Remove an expense by its identifier.
   Future<void> deleteExpense(String id) async {

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -23,6 +23,15 @@ class ExpenseService {
     }
   }
 
+  Future<Expense> getExpense(String id) async {
+    try {
+      final res = await _client.get("/expenses/$id");
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
   Future<Expense> createExpense(
     String groupId,
     String description,
@@ -71,6 +80,15 @@ class ExpenseService {
         if (participants != null) "participants": participants,
       };
       final res = await _client.put("/expenses/$id", data: data);
+      return Expense.fromJson(res.data);
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<Expense> approveExpense(String id) async {
+    try {
+      final res = await _client.post("/expenses/$id/approve");
       return Expense.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);

--- a/lib/state/expenses/expense_provider.dart
+++ b/lib/state/expenses/expense_provider.dart
@@ -69,6 +69,43 @@ class ExpenseNotifier extends StateNotifier<ExpenseState> {
     }
   }
 
+  Future<void> fetchExpense(String id) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final expense = await _repo.getExpense(id);
+      var expenses = state.expenses.map((e) => e.id == id ? expense : e).toList();
+      if (!expenses.any((e) => e.id == id)) {
+        expenses = [...expenses, expense];
+      }
+      state = state.copyWith(expenses: expenses, isLoading: false);
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.response?.data['message'] ?? e.message,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> approveExpense(String id) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final updated = await _repo.approveExpense(id);
+      state = state.copyWith(
+        expenses: state.expenses.map((e) => e.id == id ? updated : e).toList(),
+        isLoading: false,
+      );
+    } on DioException catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.response?.data['message'] ?? e.message,
+      );
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
   Expense? getById(String id) {
     try {
       return state.expenses.firstWhere((e) => e.id == id);


### PR DESCRIPTION
## Summary
- Add `getExpense` and `approveExpense` methods in `ExpenseService`
- Expose new methods through `ExpenseRepository` and `ExpenseNotifier`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c37e1108324af26a685eb519f77