### PR TITLE
Add group counts and image URL fields

### DIFF
--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -5,6 +5,9 @@ class Group {
   final String? createdBy;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final int? memberCount;
+  final int? expenseCount;
+  final String? imageUrl;
 
   Group({
     required this.id,
@@ -13,6 +16,9 @@ class Group {
     this.createdBy,
     this.createdAt,
     this.updatedAt,
+    this.memberCount,
+    this.expenseCount,
+    this.imageUrl,
   });
 
   factory Group.fromJson(Map<String, dynamic> json) => Group(
@@ -21,6 +27,12 @@ class Group {
         description: json['description'],
         createdBy:
             json['created_by']?.toString() ?? json['createdBy']?.toString(),
+        memberCount: (json['member_count'] as num? ?? json['memberCount'] as num?)
+            ?.toInt(),
+        expenseCount: (json['expense_count'] as num? ??
+                json['expenseCount'] as num?)
+            ?.toInt(),
+        imageUrl: json['image_url']?.toString() ?? json['imageUrl']?.toString(),
         createdAt: json['created_at'] != null
             ? DateTime.parse(json['created_at'])
             : json['createdAt'] != null
@@ -40,5 +52,8 @@ class Group {
         'created_by': createdBy,
         'created_at': createdAt?.toIso8601String(),
         'updated_at': updatedAt?.toIso8601String(),
+        'member_count': memberCount,
+        'expense_count': expenseCount,
+        'image_url': imageUrl,
       };
 }

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -7,11 +7,35 @@ class GroupRepository {
   GroupRepository(this._service);
 
   Future<List<Group>> getGroups() async {
-    return _service.getGroups();
+    final groups = await _service.getGroups();
+    return groups
+        .map((g) => Group(
+              id: g.id,
+              name: g.name,
+              description: g.description,
+              createdBy: g.createdBy,
+              createdAt: g.createdAt,
+              updatedAt: g.updatedAt,
+              memberCount: g.memberCount,
+              expenseCount: g.expenseCount,
+              imageUrl: g.imageUrl,
+            ))
+        .toList();
   }
 
   Future<Group> getGroup(String id) async {
-    return _service.getGroup(id);
+    final g = await _service.getGroup(id);
+    return Group(
+      id: g.id,
+      name: g.name,
+      description: g.description,
+      createdBy: g.createdBy,
+      createdAt: g.createdAt,
+      updatedAt: g.updatedAt,
+      memberCount: g.memberCount,
+      expenseCount: g.expenseCount,
+      imageUrl: g.imageUrl,
+    );
   }
 
   Future<Group> createGroup(String name, {String? description}) async {

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -11,7 +11,17 @@ class GroupService {
     try {
       final res = await _client.get("/groups");
       final data = res.data as List;
-      return data.map((e) => Group.fromJson(e)).toList();
+      return data.map((e) {
+        if (e is Map<String, dynamic>) {
+          if (e['member_count'] == null && e['members'] is List) {
+            e['member_count'] = (e['members'] as List).length;
+          }
+          if (e['expense_count'] == null && e['expenses'] is List) {
+            e['expense_count'] = (e['expenses'] as List).length;
+          }
+        }
+        return Group.fromJson(e);
+      }).toList();
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }
@@ -20,6 +30,16 @@ class GroupService {
   Future<Group> getGroup(String id) async {
     try {
       final res = await _client.get("/groups/$id");
+      final data = res.data;
+      if (data is Map<String, dynamic>) {
+        if (data['member_count'] == null && data['members'] is List) {
+          data['member_count'] = (data['members'] as List).length;
+        }
+        if (data['expense_count'] == null && data['expenses'] is List) {
+          data['expense_count'] = (data['expenses'] as List).length;
+        }
+        return Group.fromJson(data);
+      }
       return Group.fromJson(res.data);
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);


### PR DESCRIPTION
## Summary
- extend `Group` model with member/expense counts and image URL
- map optional count fields in group service and repository
- support fallbacks when API responses miss count data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba42ca5f5c8324972fbe45fbfefa86