### PR TITLE
feat: show group details with members and balances

### DIFF
--- a/lib/config/locator.dart
+++ b/lib/config/locator.dart
@@ -42,10 +42,10 @@ Future<void> setupLocator() async {
 
   // Repositories
   locator.registerLazySingleton<AuthRepository>(() => AuthRepository(locator<AuthService>()));
-  locator.registerLazySingleton<GroupRepository>(
-      () => GroupRepository(locator<GroupService>()));
   locator.registerLazySingleton<ExpenseRepository>(
       () => ExpenseRepository(locator<ExpenseService>()));
+  locator.registerLazySingleton<GroupRepository>(
+      () => GroupRepository(locator<GroupService>(), locator<ExpenseRepository>()));
   locator.registerLazySingleton<InvitationRepository>(() => InvitationRepository(locator<InvitationService>()));
   locator.registerLazySingleton<PaymentRepository>(() => PaymentRepository(locator<PaymentService>()));
   locator.registerLazySingleton<NotificationRepository>(() => NotificationRepository(locator<NotificationService>()));

--- a/lib/repositories/group_repository.dart
+++ b/lib/repositories/group_repository.dart
@@ -1,10 +1,14 @@
 import '../models/group.dart';
+import '../models/user.dart';
+import '../models/expense.dart';
 import '../services/group_service.dart';
+import 'expense_repository.dart';
 
 class GroupRepository {
   final GroupService _service;
+  final ExpenseRepository _expenseRepo;
 
-  GroupRepository(this._service);
+  GroupRepository(this._service, this._expenseRepo);
 
   Future<List<Group>> getGroups() async {
     return _service.getGroups();
@@ -37,6 +41,14 @@ class GroupRepository {
 
   Future<void> deleteMember(String groupId, String memberId) async {
     await _service.deleteMember(groupId, memberId);
+  }
+
+  Future<List<User>> getMembers(String groupId) async {
+    return _service.getMembers(groupId);
+  }
+
+  Future<List<Expense>> getExpenses(String groupId) async {
+    return _expenseRepo.getExpenses(groupId);
   }
 
   Future<List<dynamic>> getBalances(String groupId) async {

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -1,6 +1,7 @@
 import "package:dio/dio.dart";
 
 import "../models/group.dart";
+import "../models/user.dart";
 import "../services/api_client.dart";
 
 class GroupService {
@@ -84,6 +85,16 @@ class GroupService {
   Future<void> deleteMember(String groupId, String memberId) async {
     try {
       await _client.delete("/groups/$groupId/members/$memberId");
+    } on DioException catch (e) {
+      throw Exception(e.response?.data["message"] ?? e.message);
+    }
+  }
+
+  Future<List<User>> getMembers(String groupId) async {
+    try {
+      final res = await _client.get("/groups/$groupId/members");
+      final data = res.data as List;
+      return data.map((e) => User.fromJson(e)).toList();
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);
     }

--- a/lib/state/groups/group_provider.dart
+++ b/lib/state/groups/group_provider.dart
@@ -3,6 +3,8 @@ import 'package:dio/dio.dart';
 import '../../config/locator.dart';
 import '../../repositories/group_repository.dart';
 import '../../models/group.dart';
+import '../../models/user.dart';
+import '../../models/expense.dart';
 import 'group_state.dart';
 
 final groupNotifierProvider =
@@ -98,11 +100,47 @@ class GroupNotifier extends StateNotifier<GroupState> {
     }
   }
 
+  Future<List<User>> getMembers(String groupId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final members = await _repo.getMembers(groupId);
+      final membersMap = Map<String, List<User>>.from(state.members);
+      membersMap[groupId] = members;
+      state = state.copyWith(members: membersMap, isLoading: false);
+      return members;
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+      return [];
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return [];
+    }
+  }
+
+  Future<List<Expense>> getExpenses(String groupId) async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final expenses = await _repo.getExpenses(groupId);
+      state = state.copyWith(isLoading: false);
+      return expenses;
+    } on DioException catch (e) {
+      state = state.copyWith(
+          isLoading: false, error: e.response?.data['message'] ?? e.message);
+      return [];
+    } catch (e) {
+      state = state.copyWith(isLoading: false, error: e.toString());
+      return [];
+    }
+  }
+
   Future<List<dynamic>> getBalances(String groupId) async {
     state = state.copyWith(isLoading: true, error: null);
     try {
       final balances = await _repo.getBalances(groupId);
-      state = state.copyWith(isLoading: false);
+      final balancesMap = Map<String, List<dynamic>>.from(state.balances);
+      balancesMap[groupId] = balances;
+      state = state.copyWith(balances: balancesMap, isLoading: false);
       return balances;
     } on DioException catch (e) {
       state = state.copyWith(

--- a/lib/state/groups/group_state.dart
+++ b/lib/state/groups/group_state.dart
@@ -1,23 +1,32 @@
 import '../../models/group.dart';
+import '../../models/user.dart';
 
 class GroupState {
   final List<Group> groups;
+  final Map<String, List<User>> members;
+  final Map<String, List<dynamic>> balances;
   final bool isLoading;
   final String? error;
 
   const GroupState({
     this.groups = const [],
+    this.members = const {},
+    this.balances = const {},
     this.isLoading = false,
     this.error,
   });
 
   GroupState copyWith({
     List<Group>? groups,
+    Map<String, List<User>>? members,
+    Map<String, List<dynamic>>? balances,
     bool? isLoading,
     String? error,
   }) {
     return GroupState(
       groups: groups ?? this.groups,
+      members: members ?? this.members,
+      balances: balances ?? this.balances,
       isLoading: isLoading ?? this.isLoading,
       error: error,
     );

--- a/lib/ui/widgets/circle_avatar_group.dart
+++ b/lib/ui/widgets/circle_avatar_group.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import '../../models/user.dart';
+
+class CircleAvatarGroup extends StatelessWidget {
+  final List<User> users;
+  final int maxVisible;
+  const CircleAvatarGroup({super.key, required this.users, this.maxVisible = 3});
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = users.take(maxVisible).toList();
+    final extraCount = users.length - visible.length;
+    return SizedBox(
+      height: 48,
+      child: Stack(
+        children: [
+          for (int i = 0; i < visible.length; i++)
+            Positioned(
+              left: i * 28,
+              child: CircleAvatar(
+                radius: 24,
+                backgroundImage: visible[i].profilePictureUrl != null
+                    ? NetworkImage(visible[i].profilePictureUrl!)
+                    : null,
+                child: visible[i].profilePictureUrl == null
+                    ? _buildFallback(visible[i])
+                    : null,
+              ),
+            ),
+          if (extraCount > 0)
+            Positioned(
+              left: visible.length * 28,
+              child: CircleAvatar(
+                radius: 24,
+                backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                child: Text('+${extraCount}',
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFallback(User user) {
+    if (user.name != null && user.name!.isNotEmpty) {
+      final parts = user.name!.trim().split(' ');
+      String initials = parts.isNotEmpty ? parts[0][0] : '';
+      if (parts.length > 1) {
+        initials += parts[1][0];
+      }
+      return Text(initials.toUpperCase());
+    }
+    if (user.email.isNotEmpty) {
+      return Text(user.email[0].toUpperCase());
+    }
+    return const Icon(Icons.person);
+  }
+}


### PR DESCRIPTION
## Summary
- add repository and service support for group members and recent expenses
- store members and balances in group state and expose retrieval methods
- display recent expenses, member avatars and balance summary on group detail view with navigation actions

## Testing
- `dart format lib/repositories/group_repository.dart lib/services/group_service.dart lib/state/groups/group_state.dart lib/state/groups/group_provider.dart lib/ui/screens/groups/group_detail_screen.dart lib/ui/widgets/circle_avatar_group.dart >/tmp/format.log && tail -n 20 /tmp/format.log` *(fails: `command not found: dart`)*
- `flutter analyze >/tmp/analyze.log && tail -n 20 /tmp/analyze.log` *(fails: `command not found: flutter`)*
- `flutter test >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba42e6882c8324a9c39ac44d963d8f