### PR TITLE
Implement dashboard model, provider and UI

### DIFF
--- a/lib/models/dashboard_data.dart
+++ b/lib/models/dashboard_data.dart
@@ -1,0 +1,16 @@
+import 'expense.dart';
+import 'payment.dart';
+import 'notification.dart';
+
+class DashboardData {
+  final List<Expense> expenses;
+  final List<Payment> payments;
+  final List<AppNotification> notifications;
+
+  const DashboardData({
+    this.expenses = const [],
+    this.payments = const [],
+    this.notifications = const [],
+  });
+}
+

--- a/lib/state/dashboard/dashboard_provider.dart
+++ b/lib/state/dashboard/dashboard_provider.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../config/locator.dart';
+import '../../models/dashboard_data.dart';
+import '../../services/expense_service.dart';
+import '../../services/payment_service.dart';
+import '../../services/notification_service.dart';
+
+/// Provides combined data for the dashboard screen.
+final dashboardProvider = FutureProvider<DashboardData>((ref) async {
+  final expenseService = locator<ExpenseService>();
+  final paymentService = locator<PaymentService>();
+  final notificationService = locator<NotificationService>();
+
+  // Fetch all data in parallel
+  final expensesFuture = expenseService.getExpenses('');
+  final paymentsFuture = paymentService.getDuePayments();
+  final notificationsFuture = notificationService.getNotifications();
+
+  final expenses = await expensesFuture;
+  final payments = await paymentsFuture;
+  final notifications = await notificationsFuture;
+
+  return DashboardData(
+    expenses: expenses,
+    payments: payments,
+    notifications: notifications,
+  );
+});
+

--- a/lib/ui/screens/dashboard_screen.dart
+++ b/lib/ui/screens/dashboard_screen.dart
@@ -1,48 +1,127 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import '../routes.dart';
+import 'package:intl/intl.dart';
 
-class DashboardScreen extends StatelessWidget {
+import '../routes.dart';
+import '../../models/expense.dart';
+import '../../models/payment.dart';
+import '../../models/notification.dart';
+import '../../state/dashboard/dashboard_provider.dart';
+import '../widgets/app_bottom_navigation.dart';
+import '../widgets/section_header.dart';
+
+class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Dashboard'),
-        actions: [
-          IconButton(
-            onPressed: () => context.push(AppRoutes.profile),
-            icon: const Icon(Icons.person),
-          )
-        ],
-      ),
-      body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
+  void _showAddOptions(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Wrap(
           children: [
-            ElevatedButton(
-              onPressed: () => context.push('/groups'),
-              child: const Text('Ver grupos'),
+            ListTile(
+              leading: const Icon(Icons.receipt),
+              title: const Text('Nuevo gasto'),
+              onTap: () {
+                Navigator.of(context).pop();
+                context.push(AppRoutes.groups); // Navigate to select group/expense
+              },
             ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/notifications'),
-              child: const Text('Notificaciones'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/recurring-payments'),
-              child: const Text('Pagos recurrentes'),
-            ),
-            const SizedBox(height: 8),
-            ElevatedButton(
-              onPressed: () => context.push('/reports'),
-              child: const Text('Reportes'),
+            ListTile(
+              leading: const Icon(Icons.payments),
+              title: const Text('Nuevo pago'),
+              onTap: () {
+                Navigator.of(context).pop();
+                context.push(AppRoutes.groups); // Navigate to select group/payment
+              },
             ),
           ],
         ),
       ),
     );
   }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dashboardAsync = ref.watch(dashboardProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => _showAddOptions(context),
+          ),
+          IconButton(
+            onPressed: () => context.push(AppRoutes.profile),
+            icon: const Icon(Icons.person),
+          ),
+        ],
+      ),
+      bottomNavigationBar: const AppBottomNavigation(currentIndex: 1),
+      body: dashboardAsync.when(
+        data: (data) => ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            const SectionHeader('Gastos Recientes'),
+            if (data.expenses.isEmpty)
+              const ListTile(title: Text('No hay gastos recientes'))
+            else
+              ...data.expenses.map(_expenseTile),
+            const SectionHeader('Deudas Pendientes'),
+            if (data.payments.isEmpty)
+              const ListTile(title: Text('No hay deudas pendientes'))
+            else
+              ...data.payments.map(_paymentTile),
+            const SectionHeader('Actividad de Grupo'),
+            if (data.notifications.isEmpty)
+              const ListTile(title: Text('Sin actividad'))
+            else
+              ...data.notifications.map(_notificationTile),
+          ],
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: \$e')),
+      ),
+    );
+  }
+
+  Widget _expenseTile(Expense e) {
+    final date = e.expenseDate != null
+        ? DateFormat.yMd().format(e.expenseDate!)
+        : '';
+    return ListTile(
+      leading: const CircleAvatar(),
+      title: Text(e.description),
+      subtitle: Text(date),
+      trailing: Text('\$${e.totalAmount.toStringAsFixed(2)}'),
+    );
+  }
+
+  Widget _paymentTile(Payment p) {
+    return ListTile(
+      leading: const CircleAvatar(),
+      title: Text(p.toUserId),
+      subtitle: Text(p.note ?? ''),
+      trailing: Text(
+        '\$${p.amount.toStringAsFixed(2)}',
+        style: const TextStyle(color: Colors.red),
+      ),
+    );
+  }
+
+  Widget _notificationTile(AppNotification n) {
+    final date = n.createdAt != null
+        ? DateFormat.Hm().format(n.createdAt!)
+        : '';
+    return ListTile(
+      leading: const CircleAvatar(),
+      title: Text(n.title),
+      subtitle: Text(n.body),
+      trailing: Text(date, style: const TextStyle(fontSize: 12)),
+    );
+  }
 }
+

--- a/lib/ui/widgets/section_header.dart
+++ b/lib/ui/widgets/section_header.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+/// Simple header used to separate sections in lists.
+class SectionHeader extends StatelessWidget {
+  final String title;
+  const SectionHeader(this.title, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 24, bottom: 8),
+      child: Text(
+        title,
+        style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `DashboardData` model holding recent expenses, due payments and notifications
- Create `dashboardProvider` to load combined dashboard data from services
- Redesign `DashboardScreen` with sections, bottom navigation and quick add actions
- Introduce reusable `SectionHeader` widget

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba42ef019c83248ac2d12bd9cf5f59