### PR TITLE
Refactor API client get signature

### DIFF
--- a/lib/repositories/payment_repository.dart
+++ b/lib/repositories/payment_repository.dart
@@ -27,7 +27,7 @@ class PaymentService {
       'startDate': startDate,
       'endDate': endDate,
     });
-    final res = await _api.get('/api/payments', queryParameters: query);
+    final res = await _api.get('/api/payments', query: query);
     final list = (res.data as List);
     return list.map((j) => Payment.fromJson(j)).toList();
   }
@@ -86,7 +86,7 @@ class PaymentService {
   // GET /api/payments/due  (query usa group_id en snake_case)
   Future<List<Payment>> getDuePayments({String? groupId}) async {
     final query = _clean({'group_id': groupId}); // ← excepción
-    final res = await _api.get('/api/payments/due', queryParameters: query);
+    final res = await _api.get('/api/payments/due', query: query);
     final list = (res.data as List);
     return list.map((j) => Payment.fromJson(j)).toList();
   }

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -48,7 +48,6 @@ class ApiClient {
   Future<Response<T>> get<T>(
     String path, {
     Map<String, dynamic>? query,
-    required Map<String, dynamic> queryParameters,
   }) => _dio.get(path, queryParameters: query);
 
   Future<Response<T>> post<T>(

--- a/lib/services/app_service.dart
+++ b/lib/services/app_service.dart
@@ -8,7 +8,7 @@ class AppService {
 
   Future<String> getAppMode() async {
     try {
-      final res = await _client.get("/app-mode", queryParameters: {});
+      final res = await _client.get("/app-mode");
       return res.data["mode"] as String;
     } on DioException catch (e) {
       throw Exception(e.response?.data["message"] ?? e.message);

--- a/lib/services/expense_service.dart
+++ b/lib/services/expense_service.dart
@@ -22,7 +22,6 @@ class ExpenseService {
       final res = await _client.get(
         "/expenses",
         query: params,
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => Expense.fromJson(e)).toList();
@@ -35,7 +34,6 @@ class ExpenseService {
     try {
       final res = await _client.get(
         "/expenses/$id",
-        queryParameters: <String, dynamic>{},
       );
       return Expense.fromJson(res.data);
     } on DioException catch (e) {

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -11,7 +11,6 @@ class GroupService {
     try {
       final res = await _client.get(
         "/groups",
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) {
@@ -34,7 +33,6 @@ class GroupService {
     try {
       final res = await _client.get(
         "/groups/$id",
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data;
       if (data is Map<String, dynamic>) {
@@ -132,7 +130,6 @@ class GroupService {
     try {
       final res = await _client.get(
         "/groups/$groupId/balances",
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data;

--- a/lib/services/invitation_service.dart
+++ b/lib/services/invitation_service.dart
@@ -16,7 +16,6 @@ class InvitationService {
           if (mine != null) "mine": mine.toString(),
           if (groupId != null) "group_id": groupId,
         },
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => Invitation.fromJson(e)).toList();

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -22,7 +22,6 @@ class NotificationService {
     try {
       final res = await _client.get(
         "/notifications",
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => AppNotification.fromJson(e)).toList();

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -26,7 +26,6 @@ class PaymentService {
           if (startDate != null) 'start_date': startDate,
           if (endDate != null) 'end_date': endDate,
         },
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => Payment.fromJson(e)).toList();
@@ -100,7 +99,6 @@ class PaymentService {
       final res = await _client.get(
         '/payments/due',
         query: {if (groupId != null) 'group_id': groupId},
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => Payment.fromJson(e)).toList();

--- a/lib/services/recurring_payment_service.dart
+++ b/lib/services/recurring_payment_service.dart
@@ -12,7 +12,6 @@ class RecurringPaymentService {
       final res = await _client.get(
         '/recurring-payments',
         query: {if (groupId != null) 'group_id': groupId},
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => RecurringPayment.fromJson(e)).toList();

--- a/lib/services/reports_service.dart
+++ b/lib/services/reports_service.dart
@@ -21,7 +21,6 @@ class ReportsService {
           if (startDate != null) 'startDate': startDate.toIso8601String(),
           if (endDate != null) 'endDate': endDate.toIso8601String(),
         },
-        queryParameters: <String, dynamic>{},
       );
       final data = res.data as List;
       return data.map((e) => Report.fromJson(e)).toList();


### PR DESCRIPTION
## Summary
- simplify ApiClient.get to accept optional query map
- remove redundant queryParameters argument from service and repository get calls

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6076cf608324bc5ce7641352dbf0