### PR TITLE
Use camelCase query parameters for payment queries

### DIFF
--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -8,7 +8,7 @@ class PaymentService {
   final ApiClient _client;
   PaymentService(this._client);
 
-  /// GET /payments[?status][&direction][&group_id][&start_date][&end_date]
+  /// GET /payments[?status][&direction][&groupId][&startDate][&endDate]
   Future<List<Payment>> getPayments({
     String? groupId,
     String? status, // "approved" | "pending" | "rejected"
@@ -20,11 +20,11 @@ class PaymentService {
       final res = await _client.get(
         '/payments',
         query: {
-          if (groupId != null) 'group_id': groupId,
+          if (groupId != null) 'groupId': groupId,
           if (status != null) 'status': status,
           if (direction != null) 'direction': direction,
-          if (startDate != null) 'start_date': startDate,
-          if (endDate != null) 'end_date': endDate,
+          if (startDate != null) 'startDate': startDate,
+          if (endDate != null) 'endDate': endDate,
         },
         queryParameters: <String, dynamic>{},
       );


### PR DESCRIPTION
## Summary
- send camelCase `groupId`, `startDate`, `endDate` query parameters in `PaymentService.getPayments`
- document `getPayments` query format

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba60793e348324939aba37bbe65cef